### PR TITLE
Implement logic to send service logs to syslog

### DIFF
--- a/jobs/nats/templates/nats_ctl.erb
+++ b/jobs/nats/templates/nats_ctl.erb
@@ -23,9 +23,14 @@ case $1 in
     echo $$ > $PIDFILE
     chown vcap:vcap $PIDFILE
 
+    exec > >(chpst -u vcap:vcap sh -c "
+        tee -a ${LOG_DIR}/nats.log | \
+        sed 's/^[0-9][0-9][0-9][0-9]\/[0-9][0-9]\/[0-9][0-9] [0-9][0-9]:[0-9][0-9]:[0-9][0-9] //' | \
+          logger -p user.info -t vcap.nats
+      ") 2>&1
+
     exec chpst -u vcap:vcap /var/vcap/packages/gnatsd/bin/gnatsd \
-         -l $LOG_DIR/nats.log \
-         -c /var/vcap/jobs/nats/config/nats.conf
+      -c /var/vcap/jobs/nats/config/nats.conf
     ;;
 
   stop)

--- a/src/nats-common/utils.sh
+++ b/src/nats-common/utils.sh
@@ -5,7 +5,7 @@ redirect_logs() {
   local CTL_FILE="$2"
 
   mkdir -p $LOG_DIRECTORY
-  exec 2>&1 > >(exec chpst -u vcap:vcap logger -p user.info -t vcap.$CTL_FILE -s 2>$LOG_DIRECTORY/$CTL_FILE.log)
+  exec > >(exec chpst -u vcap:vcap logger -p user.info -t vcap.$CTL_FILE -s 2>$LOG_DIRECTORY/$CTL_FILE.log) 2>&1
 }
 
 pid_guard() {


### PR DESCRIPTION
# Motivation

Several of the CF and Diego platform services send logs to the local syslog, tagged as `vcap.*`. . The [metron agent from loggregrator configures the local syslog to send the logs to metron](https://github.com/cloudfoundry/loggregator/blob/develop/jobs/metron_agent/spec#L29) so that later can be sent to a centralised logging service. 

In some cases it is the service application itself who sends the logs to syslog, but it seems to be a common pattern across CF and Diego services to [let the service log to stdout/stderr, and redirect that output to local files or syslog](https://github.com/cloudfoundry/diego-release/blob/develop/jobs/bbs/templates/bbs_as_vcap.erb#L91) using the [`logger` command](http://linux.die.net/man/1/logger). 

Not all the services implement this feature, and instead they only log to local files. In order to centralise all the logs, so we will add the logic required to send the logs of the missing services. 

We will implement the *log to stdout and redirect  to `logger` pattern* whenever is possible.

## Implementation in nats release

We will implement this for the nats job.

We add a property `nats.log_to_syslog`. When true, we redirect the stdout and stderr in the ctl script into syslog following the standard vcap pattern, in addition to files.

[Nats will print the logs to stdout if no log option is specified](http://nats.io/documentation/server/gnatsd-logging/), so enabling this will remove the `-l` option passed to nats.

Note that more modern versions of gnatsd can send logs directly, but we keep using the redirect to `logger` to keep consistency with the rest of the CF ecosystem and to be able to override the tag.

We also fixed an issue in the redirect for the `nats_ctl` script

## How to review? 

Enable the `nats.log_to_syslog` and deploy. Logs should be sent to syslog. If metron agent is installed locally, the logs will be redirected to metron agent the loggregrator.

## Open questions

This PR is open to debate for several open questions:

 * Is OK to add a specific property to enable nats logs to syslog? or should this be enabled by default?
 * Is the tag `vcap.nats` the most appropriate one? the `nats_stream_forwarder` job uses the same for forwarding the raw nats messages.
 * Shall we create or use helper for this feature? 




