### PR TITLE
gem install --local

### DIFF
--- a/packages/ruby-2.2.5/packaging
+++ b/packages/ruby-2.2.5/packaging
@@ -29,4 +29,4 @@ tar xzf ruby-2.2.5/ruby-${RUBY_VERSION}.tar.gz
   make install
 )
 
-${BOSH_INSTALL_TARGET}/bin/gem install ruby-2.2.5/bundler-${BUNDLER_VERSION}.gem --no-ri --no-rdoc
+${BOSH_INSTALL_TARGET}/bin/gem install ruby-2.2.5/bundler-${BUNDLER_VERSION}.gem --local --no-ri --no-rdoc


### PR DESCRIPTION
Avoid slowdowns and timeouts in case the compilation VMs can't access the internet.
The same thing is done in the ruby packages in cf-release:  

- https://github.com/cloudfoundry/cf-release/blob/690e8155510acac067193f1076c74ce6312c0479/packages/ruby-2.3/packaging#L31
- https://github.com/cloudfoundry/cf-release/blob/690e8155510acac067193f1076c74ce6312c0479/packages/ruby-2.1.8/packaging#L32