### PR TITLE
Provide the monitor port as well as the port 

### DIFF
--- a/jobs/nats/spec
+++ b/jobs/nats/spec
@@ -18,6 +18,7 @@ provides:
   - nats.user
   - nats.password
   - nats.port
+  - nats.monitor_port
 
 consumes:
 - name: nats


### PR DESCRIPTION
Proivide the monitor_port through bosh links to allow external monitoring agents to discover the monitoring port if required.