### PR TITLE
Add intra-cluster TLS properties

### DIFF
--- a/example-manifests/ops-files/internal_tls.yml
+++ b/example-manifests/ops-files/internal_tls.yml
@@ -1,0 +1,44 @@
+# We need to ensure that we're using BOSH DNS so that our certificates can have
+# dependable hostnames.
+- type: replace
+  path: /features?/use_dns_addresses?
+  value: true
+
+- type: replace
+  path: /variables?/name=nats_internal_ca?
+  value:
+    name: nats_internal_ca
+    type: certificate
+    options:
+      is_ca: true
+      common_name: nats_internal
+
+- type: replace
+  path: /variables?/name=nats_internal_cert?
+  value:
+    name: nats_internal_cert
+    type: certificate
+    options:
+      ca: nats_internal_ca
+      common_name: "*.nats-server.default.nats.bosh"
+      alternative_names:
+      - "*.nats-server.default.nats.bosh"
+      extended_key_usage:
+      - client_auth
+      - server_auth
+
+- type: replace
+  path: /instance_groups/name=nats-server/jobs/name=nats/properties/nats?/cluster_tls?/enabled
+  value: true
+
+- type: replace
+  path: /instance_groups/name=nats-server/jobs/name=nats/properties/nats?/cluster_tls?/pki?/ca
+  value: "((nats_internal_cert.ca))"
+
+- type: replace
+  path: /instance_groups/name=nats-server/jobs/name=nats/properties/nats?/cluster_tls?/pki?/certificate
+  value: "((nats_internal_cert.certificate))"
+
+- type: replace
+  path: /instance_groups/name=nats-server/jobs/name=nats/properties/nats?/cluster_tls?/pki?/private_key
+  value: "((nats_internal_cert.private_key))"

--- a/jobs/nats/spec
+++ b/jobs/nats/spec
@@ -8,6 +8,10 @@ templates:
   pre-start.erb: bin/pre-start
   bpm.yml.erb: config/bpm.yml
 
+  internal_tls/ca.pem.erb: config/internal_tls/ca.pem
+  internal_tls/certificate.pem.erb: config/internal_tls/certificate.pem
+  internal_tls/private_key.pem.erb: config/internal_tls/private_key.pem
+
 packages:
   - gnatsd
 
@@ -49,3 +53,13 @@ properties:
   nats.prof_port:
     description: "Port for pprof. 0 means disabled."
     default: 0
+
+  nats.cluster_tls.enabled:
+    description: "Enable mTLS for the cluster-internal network traffic between NATS servers."
+    default: false
+  nats.cluster_tls.pki.ca:
+    description: "The PEM-encoded certificate of the certificate authority to use for verifying the TLS connections of cluster-internal traffic."
+  nats.cluster_tls.pki.certificate:
+    description: "The PEM-encoded certificate to use for verifying the TLS connections of cluster-internal traffic."
+  nats.cluster_tls.pki.private_key:
+    description: "The PEM-encoded private key to use for verifying the TLS connections of cluster-internal traffic."

--- a/jobs/nats/templates/internal_tls/ca.pem.erb
+++ b/jobs/nats/templates/internal_tls/ca.pem.erb
@@ -1,0 +1,3 @@
+<% if p("nats.cluster_tls.enabled") -%>
+<%= p("nats.cluster_tls.pki.ca") %>
+<% end -%>

--- a/jobs/nats/templates/internal_tls/certificate.pem.erb
+++ b/jobs/nats/templates/internal_tls/certificate.pem.erb
@@ -1,0 +1,3 @@
+<% if p("nats.cluster_tls.enabled") -%>
+<%= p("nats.cluster_tls.pki.certificate") %>
+<% end -%>

--- a/jobs/nats/templates/internal_tls/private_key.pem.erb
+++ b/jobs/nats/templates/internal_tls/private_key.pem.erb
@@ -1,0 +1,3 @@
+<% if p("nats.cluster_tls.enabled") -%>
+<%= p("nats.cluster_tls.pki.private_key") %>
+<% end -%>

--- a/jobs/nats/templates/nats.conf.erb
+++ b/jobs/nats/templates/nats.conf.erb
@@ -61,6 +61,23 @@ cluster {
     timeout: <%= p("nats.authorization_timeout") %>
   }
 
+  <% if p("nats.cluster_tls.enabled") -%>
+  tls {
+    ca_file: "/var/vcap/jobs/nats/config/internal_tls/ca.pem"
+    cert_file: "/var/vcap/jobs/nats/config/internal_tls/certificate.pem"
+    key_file: "/var/vcap/jobs/nats/config/internal_tls/private_key.pem"
+    cipher_suites: [
+      "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+      "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+    ]
+    curve_preferences: [
+      "CurveP384"
+    ]
+    timeout: 5 # seconds
+    verify: true
+  }
+  <% end -%>
+
   routes = [
     <% (nats_ips - [self_ip] - [self_host]).each do |address| %>
     nats-route://<%= p("nats.user") %>:<%= p("nats.password") %>@<%= address %>:<%= p("nats.port") + 1 %>


### PR DESCRIPTION
This allows an operator to encrypt the internal traffic between NATS servers (server to client traffic is unaffected).

This PR also contains an ops-file which can be used with the default manifest in this repository to enable the feature. I've tested this change both using the smoke tests in this repository and by running the CATs against a CF which has this version of NATS deployed and this feature enabled.

This PR **does not** enable this in CI yet. I was going to do that in another PR.