### PR TITLE
Open monitor port on localhost as well

### DIFF
--- a/jobs/nats-tls/templates/nats-tls.conf.erb
+++ b/jobs/nats-tls/templates/nats-tls.conf.erb
@@ -44,7 +44,7 @@
 net: "<%= spec.address %>"
 port: <%= p("nats.port") %>
 prof_port: <%= p("nats.prof_port") %>
-monitor_port: <%= p("nats.monitor_port") %>
+http: "0.0.0.0:<%= p("nats.monitor_port") %>"
 
 debug: <%= p("nats.debug") %>
 trace: <%= p("nats.trace") %>

--- a/jobs/nats/templates/nats.conf.erb
+++ b/jobs/nats/templates/nats.conf.erb
@@ -44,7 +44,7 @@
 net: "<%= spec.address %>"
 port: <%= p("nats.port") %>
 prof_port: <%= p("nats.prof_port") %>
-monitor_port: <%= p("nats.monitor_port") %>
+http: "0.0.0.0:<%= p("nats.monitor_port") %>"
 
 debug: <%= p("nats.debug") %>
 trace: <%= p("nats.trace") %>

--- a/spec/nats-tls/nats_tls_config_spec.rb
+++ b/spec/nats-tls/nats_tls_config_spec.rb
@@ -21,7 +21,7 @@ module Bosh::Template::Test
             'no_advertise' => false,
             'debug' => false,
             'trace' => false,
-            'monitor_port' => 0,
+            'http' => '0.0.0.0:0',
             'prof_port' => 0,
             'external' => {
               'tls' => {
@@ -57,7 +57,7 @@ module Bosh::Template::Test
                 'hostname' => 'my-host',
                 'port' => 4222,
                 'cluster_port' => 4223,
-                'monitor_port' => 0
+                'http' => '0.0.0.0:0'
               }
             }
           )
@@ -83,7 +83,7 @@ expected_template =  %{
 net: "10.0.0.1"
 port: 4222
 prof_port: 0
-monitor_port: 0
+http: "0.0.0.0:0"
 
 debug: false
 trace: false
@@ -160,7 +160,7 @@ expected_template =  %{
 net: "10.0.0.1"
 port: 4222
 prof_port: 0
-monitor_port: 0
+http: "0.0.0.0:0"
 
 debug: false
 trace: false

--- a/spec/nats/nats_config_spec.rb
+++ b/spec/nats/nats_config_spec.rb
@@ -21,7 +21,7 @@ module Bosh::Template::Test
             'no_advertise' => true,
             'debug' => false,
             'trace' => false,
-            'monitor_port' => 0,
+            'http' => '0.0.0.0:0',
             'prof_port' => 0,
             'internal' => {
               'tls' => {
@@ -50,7 +50,7 @@ module Bosh::Template::Test
                 'hostname' => 'my-host',
                 'port' => 4222,
                 'cluster_port' => 4223,
-                'monitor_port' => 0
+                'http' => '0.0.0.0:0'
               }
             }
           )
@@ -76,7 +76,7 @@ expected_template =  %{
 net: "10.0.0.1"
 port: 4222
 prof_port: 0
-monitor_port: 0
+http: "0.0.0.0:0"
 
 debug: false
 trace: false
@@ -138,7 +138,7 @@ expected_template =  %{
 net: "10.0.0.1"
 port: 4222
 prof_port: 0
-monitor_port: 0
+http: "0.0.0.0:0"
 
 debug: false
 trace: false


### PR DESCRIPTION
In our CF deployment we are facing the issue that we can't use the metrics port of NATS in a BOSH environment.
The main reason is that the BOSH instance ip (`spec.address`) is used for both the regular NATS client port and the monitor port. However, when trying to consume the metrics via another BOSH job (e.g. telegraf, https://github.com/joek/telegraf-boshrelease) you need to specify the address to scrape the metrics from, but BOSH has no means of describing something like `spec.address` in a deployment manifest. So the monitor port is unusable for us right now.

This PR opens the monitor port on both `spec.address` (the instance IP) as well as `localhost`, so that co-located jobs can easily access the metrics and forward them to influx or other time series dbs.