### PR TITLE
Mark nats and nats-tls jobs as unhealthy if TCP connect fails

### DIFF
--- a/jobs/nats-tls/monit
+++ b/jobs/nats-tls/monit
@@ -5,4 +5,4 @@ check process nats-tls
   group vcap
   if totalmem > 500 Mb for 2 cycles then alert
   if totalmem > 3000 Mb then restart
-
+  if failed host <%= spec.address %> port <%= p("nats.port") %> type tcp then alert

--- a/jobs/nats/monit
+++ b/jobs/nats/monit
@@ -5,4 +5,4 @@ check process nats
   group vcap
   if totalmem > 500 Mb for 2 cycles then alert
   if totalmem > 3000 Mb then restart
-
+  if failed host <%= spec.address %> port <%= p("nats.port") %> type tcp then alert


### PR DESCRIPTION
- We've seen some deployments where NATS becomes unable to handle new
connections during high load. Existing connections keep working, and
many NATS client libraries will not print that they are unable to
connect (since they keep retrying new peers).
- Monit makes an easy to use TCP health check, so all I'm doing here is marking
the BOSH job as unhealthy so that anyone using BOSH health-monitor will
get a heads up that this NATS server is failing partially/fully.