### PR TITLE
Enable nats.machines to have both tls and nontls ports in peer routes

### DIFF
--- a/jobs/nats-tls/spec
+++ b/jobs/nats-tls/spec
@@ -52,11 +52,13 @@ properties:
   nats.cluster_port:
     description: "The port for the NATS servers to communicate with other servers in the cluster."
     default: 4225
+  nats.nontls_cluster_port:
+    description: "The port for the NATS servers to communicate with other servers in the cluster. No default but usually 4223."
   nats.authorization_timeout:
     description: "After accepting a connection, wait up to this many seconds for credentials."
     default: 15
   nats.machines:
-    description: "IP of each NATS cluster member."
+    description: "IP or Domain Name of each NATS cluster member."
   nats.debug:
     description: "Enable debug logging output."
     default: false

--- a/jobs/nats-tls/templates/nats-tls.conf.erb
+++ b/jobs/nats-tls/templates/nats-tls.conf.erb
@@ -20,8 +20,9 @@
   nats_peers = nil
 
   if_p("nats.machines") do |ips|
-    nats_peers = ips.map do |ip|
-      NatsPeer.new(nil, ip, p("nats.cluster_port"), p("nats.user"), p("nats.password"))
+    NatsPeer.new(nil, ip, p("nats.cluster_port"), p("nats.user"), p("nats.password"))
+    if_p("nats.nontls_cluster_port") do |nontls_cluster_port|
+      NatsPeer.new(nil, ip, nontls_cluster_port, p("nats.user"), p("nats.password"))
     end
   end
 

--- a/jobs/nats/spec
+++ b/jobs/nats/spec
@@ -48,7 +48,7 @@ properties:
     description: "The port for the NATS servers to communicate with other servers in the cluster."
     default: 4223
   nats.tls_cluster_port:
-    description: "The port for the NATS servers to communicate with other servers in the cluster (no default but usually 4225)."
+    description: "The port for the NATS servers to communicate with other servers in the cluster. No default but usually 4225."
   nats.authorization_timeout:
     description: "After accepting a connection, wait up to this many seconds for credentials."
     default: 15

--- a/jobs/nats/spec
+++ b/jobs/nats/spec
@@ -47,11 +47,13 @@ properties:
   nats.cluster_port:
     description: "The port for the NATS servers to communicate with other servers in the cluster."
     default: 4223
+  nats.tls_cluster_port:
+    description: "The port for the NATS servers to communicate with other servers in the cluster (no default but usually 4225)."
   nats.authorization_timeout:
     description: "After accepting a connection, wait up to this many seconds for credentials."
     default: 15
   nats.machines:
-    description: "IP of each NATS cluster member."
+    description: "IP or Domain Name of each NATS cluster member."
   nats.debug:
     description: "Enable debug logging output."
     default: false

--- a/jobs/nats/templates/nats.conf.erb
+++ b/jobs/nats/templates/nats.conf.erb
@@ -22,6 +22,9 @@
   if_p("nats.machines") do |ips|
     nats_peers = ips.map do |ip|
       NatsPeer.new(nil, ip, p("nats.cluster_port"), p("nats.user"), p("nats.password"))
+      if_p("nats.tls_cluster_port") do |tls_cluster_port|
+        NatsPeer.new(nil, ip, tls_cluster_port, p("nats.user"), p("nats.password"))
+      end
     end
   end
 


### PR DESCRIPTION
If we use nats.machines to override the list of IPs (or domain names) the current code will only add 1 route per server.   But currently we have both nats and nats-tls defined.

The new code will always add the peer with the same port but also optionally add the peer with the tls or non-tls port if this is also overridden.

Thanks,

Andrew