### PR TITLE
Make write_deadline configurable

### DIFF
--- a/jobs/nats-tls/spec
+++ b/jobs/nats-tls/spec
@@ -30,6 +30,7 @@ provides:
   - nats.monitor_port
   - nats.cluster_port
   - nats.external.tls.ca
+  - nats.write_deadline
 
 consumes:
 - name: nats
@@ -74,6 +75,9 @@ properties:
   nats.no_advertise:
     description: "When configured to true, this nats server will not be advertised to any nats clients."
     default: true
+  nats.write_deadline:
+    description: "Maximum number of seconds the server will block when writing. Once this threshold is exceeded the connection will be closed and the client will be considered as Slow Consumer."
+    default: "2s"
 
   nats.external.tls.ca:
     description: "Certificate of the CA for publisher/subscriber traffic. In PEM format."

--- a/jobs/nats-tls/templates/nats-tls.conf.erb
+++ b/jobs/nats-tls/templates/nats-tls.conf.erb
@@ -46,6 +46,7 @@ net: "<%= spec.address %>"
 port: <%= p("nats.port") %>
 prof_port: <%= p("nats.prof_port") %>
 http: "0.0.0.0:<%= p("nats.monitor_port") %>"
+write_deadline: "<%= p("nats.write_deadline") %>"
 
 debug: <%= p("nats.debug") %>
 trace: <%= p("nats.trace") %>

--- a/jobs/nats/spec
+++ b/jobs/nats/spec
@@ -25,6 +25,7 @@ provides:
   - nats.port
   - nats.monitor_port
   - nats.cluster_port
+  - nats.write_deadline
 
 consumes:
 - name: nats
@@ -69,6 +70,9 @@ properties:
   nats.no_advertise:
     description: "When configured to true, this nats server will not be advertised to any nats clients. This is defaulted to false for backwards compatability."
     default: false
+  nats.write_deadline:
+    description: "Maximum number of seconds the server will block when writing. Once this threshold is exceeded the connection will be closed and the client will be considered as Slow Consumer."
+    default: 2s
   nats.internal.tls.enabled:
     description: "Enable mutually authenticated TLS for NATS cluster-internal traffic."
     default: false
@@ -78,3 +82,4 @@ properties:
     description: "Certificate for cluster-internal traffic. In PEM format."
   nats.internal.tls.private_key:
     description: "Private key for cluster-internal traffic. In PEM format."
+

--- a/jobs/nats/templates/nats.conf.erb
+++ b/jobs/nats/templates/nats.conf.erb
@@ -48,6 +48,7 @@ net: "<%= spec.address %>"
 port: <%= p("nats.port") %>
 prof_port: <%= p("nats.prof_port") %>
 http: "0.0.0.0:<%= p("nats.monitor_port") %>"
+write_deadline: "<%= p("nats.write_deadline") %>"
 
 debug: <%= p("nats.debug") %>
 trace: <%= p("nats.trace") %>


### PR DESCRIPTION
As nats community recommends to increase this timeout for certain scenarios, it should be configurable.
With nats v-2.x the default is even set to 10s.