### PR TITLE
Fix tls-handshake error of bosh healthcheck

### DIFF
--- a/jobs/nats-tls/monit
+++ b/jobs/nats-tls/monit
@@ -5,4 +5,6 @@ check process nats-tls
   group vcap
   if totalmem > 500 Mb for 2 cycles then alert
   if totalmem > 3000 Mb then restart
-  if failed host <%= spec.address %> port <%= p("nats.port") %> type tcp then alert
+  if failed host <%= spec.address %> port <%= p("nats.monitor_port") %> 
+    protocol http and request "/varz"
+    then alert

--- a/jobs/nats/monit
+++ b/jobs/nats/monit
@@ -5,4 +5,6 @@ check process nats
   group vcap
   if totalmem > 500 Mb for 2 cycles then alert
   if totalmem > 3000 Mb then restart
-  if failed host <%= spec.address %> port <%= p("nats.port") %> type tcp then alert
+  if failed host <%= spec.address %> port <%= p("nats.monitor_port") %> 
+    protocol http and request "/varz"
+    then alert


### PR DESCRIPTION
To get rid of the TLS Handshake errors (#32) I changed the bosh health check to monitor port 8222 as suggested by @wallyqs.
```  
if failed host <%= spec.address %> port <%= p("nats.monitor_port") %> 
    protocol http and request "/varz"
    then alert
```
I changed both `jobs/nats/monit` and `jobs/nats-tls/monit` to be consistent.