### PR TITLE
Correct the nats.machines override code to generate the correct config

### DIFF
--- a/jobs/nats-tls/templates/nats-tls.conf.erb
+++ b/jobs/nats-tls/templates/nats-tls.conf.erb
@@ -20,9 +20,13 @@
   nats_peers = nil
 
   if_p("nats.machines") do |ips|
-    NatsPeer.new(nil, ip, p("nats.cluster_port"), p("nats.user"), p("nats.password"))
+    nats_peers = ips.map do |ip|
+      NatsPeer.new(nil, ip, p("nats.cluster_port"), p("nats.user"), p("nats.password"))
+    end
     if_p("nats.nontls_cluster_port") do |nontls_cluster_port|
-      NatsPeer.new(nil, ip, nontls_cluster_port, p("nats.user"), p("nats.password"))
+      nats_peers += ips.map do |ip|
+        NatsPeer.new(nil, ip, nontls_cluster_port, p("nats.user"), p("nats.password"))
+      end
     end
   end
 

--- a/jobs/nats/templates/nats.conf.erb
+++ b/jobs/nats/templates/nats.conf.erb
@@ -22,7 +22,9 @@
   if_p("nats.machines") do |ips|
     nats_peers = ips.map do |ip|
       NatsPeer.new(nil, ip, p("nats.cluster_port"), p("nats.user"), p("nats.password"))
-      if_p("nats.tls_cluster_port") do |tls_cluster_port|
+    end
+    if_p("nats.tls_cluster_port") do |tls_cluster_port|
+      nats_peers += ips.map do |ip|
         NatsPeer.new(nil, ip, tls_cluster_port, p("nats.user"), p("nats.password"))
       end
     end

--- a/spec/nats-tls/nats_tls_config_spec.rb
+++ b/spec/nats-tls/nats_tls_config_spec.rb
@@ -84,6 +84,7 @@ net: "10.0.0.1"
 port: 4222
 prof_port: 0
 http: "0.0.0.0:0"
+write_deadline: "2s"
 
 debug: false
 trace: false
@@ -161,6 +162,7 @@ net: "10.0.0.1"
 port: 4222
 prof_port: 0
 http: "0.0.0.0:0"
+write_deadline: "2s"
 
 debug: false
 trace: false
@@ -220,6 +222,91 @@ cluster \{
     nats-route://my-user:my-password@192.0.0.1:4223
     
     nats-route://my-user:my-password@198.5.4.3:4223
+    
+  \]
+\}
+}
+
+              expect(rendered_template).to include(expected_template)
+            end
+          end
+          describe 'nats machine ips and nontls_cluster_port are provided' do
+            before do
+              merged_manifest_properties['nats']['machines'] = ['192.0.0.1', '198.5.4.3']
+              merged_manifest_properties['nats']['nontls_cluster_port'] = '4225'
+            end
+
+            it 'renders the template with the provided manifest properties' do
+              rendered_template = template.render(merged_manifest_properties, consumes: links, spec: spec)
+expected_template =  %{
+net: "10.0.0.1"
+port: 4222
+prof_port: 0
+http: "0.0.0.0:0"
+write_deadline: "2s"
+
+debug: false
+trace: false
+logtime: true
+
+authorization \{
+  user: "my-user"
+  password: "my-password"
+  timeout: 15
+\}
+
+tls \{
+  ca_file: "/var/vcap/jobs/nats-tls/config/external_tls/ca.pem"
+  cert_file: "/var/vcap/jobs/nats-tls/config/external_tls/certificate.pem"
+  key_file: "/var/vcap/jobs/nats-tls/config/external_tls/private_key.pem"
+  cipher_suites: \[
+    "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+    "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+  \]
+  curve_preferences: \[
+    "CurveP384"
+  \]
+  timeout: 5 # seconds
+  verify: true
+\}
+
+cluster \{
+  no_advertise: false
+  host: "10.0.0.1"
+  port: 4223
+
+  authorization \{
+    user: "my-user"
+    password: "my-password"
+    timeout: 15
+  \}
+
+  
+  tls \{
+    ca_file: "/var/vcap/jobs/nats-tls/config/internal_tls/ca.pem"
+    cert_file: "/var/vcap/jobs/nats-tls/config/internal_tls/certificate.pem"
+    key_file: "/var/vcap/jobs/nats-tls/config/internal_tls/private_key.pem"
+    cipher_suites: \[
+      "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+      "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+    \]
+    curve_preferences: \[
+      "CurveP384"
+    \]
+    timeout: 5 # seconds
+    verify: true
+  \}
+  
+
+  routes = \[
+    
+    nats-route://my-user:my-password@192.0.0.1:4223
+    
+    nats-route://my-user:my-password@198.5.4.3:4223
+    
+    nats-route://my-user:my-password@192.0.0.1:4225
+    
+    nats-route://my-user:my-password@198.5.4.3:4225
     
   \]
 \}

--- a/spec/nats/nats_config_spec.rb
+++ b/spec/nats/nats_config_spec.rb
@@ -77,6 +77,7 @@ net: "10.0.0.1"
 port: 4222
 prof_port: 0
 http: "0.0.0.0:0"
+write_deadline: "2s"
 
 debug: false
 trace: false
@@ -139,6 +140,7 @@ net: "10.0.0.1"
 port: 4222
 prof_port: 0
 http: "0.0.0.0:0"
+write_deadline: "2s"
 
 debug: false
 trace: false
@@ -183,6 +185,76 @@ cluster \{
     nats-route://my-user:my-password@192.0.0.1:4223
     
     nats-route://my-user:my-password@198.5.4.3:4223
+    
+  \]
+\}
+}
+
+              expect(rendered_template).to include(expected_template)
+            end
+          end
+          describe 'nats machine ips and tls_cluster_port are provided' do
+            before do
+              merged_manifest_properties['nats']['machines'] = ['192.0.0.1', '198.5.4.3']
+              merged_manifest_properties['nats']['tls_cluster_port'] = '4225'
+            end
+
+            it 'renders the template with the provided manifest properties' do
+              rendered_template = template.render(merged_manifest_properties, consumes: links, spec: spec)
+expected_template =  %{
+net: "10.0.0.1"
+port: 4222
+prof_port: 0
+http: "0.0.0.0:0"
+write_deadline: "2s"
+
+debug: false
+trace: false
+logtime: true
+
+authorization \{
+  user: "my-user"
+  password: "my-password"
+  timeout: 15
+\}
+
+cluster \{
+  no_advertise: true
+  host: "10.0.0.1"
+  port: 4223
+
+  authorization \{
+    user: "my-user"
+    password: "my-password"
+    timeout: 15
+  \}
+
+  
+  tls \{
+    ca_file: "/var/vcap/jobs/nats/config/internal_tls/ca.pem"
+    cert_file: "/var/vcap/jobs/nats/config/internal_tls/certificate.pem"
+    key_file: "/var/vcap/jobs/nats/config/internal_tls/private_key.pem"
+    cipher_suites: \[
+      "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+      "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+    \]
+    curve_preferences: \[
+      "CurveP384"
+    \]
+    timeout: 5 # seconds
+    verify: true
+  \}
+  
+
+  routes = \[
+    
+    nats-route://my-user:my-password@192.0.0.1:4223
+    
+    nats-route://my-user:my-password@198.5.4.3:4223
+    
+    nats-route://my-user:my-password@192.0.0.1:4225
+    
+    nats-route://my-user:my-password@198.5.4.3:4225
     
   \]
 \}


### PR DESCRIPTION
The original PR I created did not work when creating the set of routes.   

This new update should fix the override of nats.machines.