### PR TITLE
Fix tls-handshake error of bosh healthcheck

### DIFF
--- a/jobs/nats-tls/monit
+++ b/jobs/nats-tls/monit
@@ -5,4 +5,6 @@ check process nats-tls
   group vcap
   if totalmem > 500 Mb for 2 cycles then alert
   if totalmem > 3000 Mb then restart
-  if failed host <%= spec.address %> port <%= p("nats.port") %> type tcp then alert
+<% if p("nats.monitor_port") != 0 -%>
+  if failed host <%= spec.address %> port <%= p("nats.monitor_port") %> type tcp then alert
+<% end -%>


### PR DESCRIPTION
This is a follow up of PR #34. 
After discussion (https://cloudfoundry.slack.com/archives/C01ABMVNE9E/p1611090474016300) the check against the `monitor_port` will be only performed if a monitor_port is defined. I changed also the http check to a simple tcp check, because of monitrc issues.

I have test it with the xenial stemcell and everything was fine.

I look forward to your feedback.

Regards,
Thomas