### PR TITLE
Make password authentication optional for nats-tls

### DIFF
--- a/jobs/nats-tls/templates/nats-tls.conf.erb
+++ b/jobs/nats-tls/templates/nats-tls.conf.erb
@@ -9,23 +9,35 @@
     end
 
     def url
+      pwd_section = ""
+      if @username and @password
+        pwd_section = "#{@username}:#{@password}@"
+      end
       if @instance_id == nil
-        "nats-route://#{@username}:#{@password}@#{@address}:#{@cluster_port}"
+        "nats-route://#{pwd_section}#{@address}:#{@cluster_port}"
       else
-        "nats-route://#{@username}:#{@password}@#{@instance_id}.#{@address}:#{@cluster_port}"
+        "nats-route://#{pwd_section}#{@instance_id}.#{@address}:#{@cluster_port}"
       end
     end
   end
 
   nats_peers = nil
+  nats_user = nil
+  nats_password = nil
+  if_p("nats.user") do |user|
+    nats_user = user
+  end
+  if_p("nats.password") do |password|
+    nats_password = password
+  end
 
   if_p("nats.machines") do |ips|
     nats_peers = ips.map do |ip|
-      NatsPeer.new(nil, ip, p("nats.cluster_port"), p("nats.user"), p("nats.password"))
+      NatsPeer.new(nil, ip, p("nats.cluster_port"), nats_user, nats_password)
     end
     if_p("nats.nontls_cluster_port") do |nontls_cluster_port|
       nats_peers += ips.map do |ip|
-        NatsPeer.new(nil, ip, nontls_cluster_port, p("nats.user"), p("nats.password"))
+        NatsPeer.new(nil, ip, nontls_cluster_port, nats_user, nats_password)
       end
     end
   end
@@ -39,8 +51,16 @@
     end
 
     if_link("nats-tls") do |nats_tls_link|
+      nats_tls_link_user = nil
+      nats_tls_link_password = nil
+      nats_tls_link.if_p("nats.user") do |user|
+        nats_tls_link_user = user
+      end
+      nats_tls_link.if_p("nats.password") do |password|
+        nats_tls_link_password = password
+      end
       nats_peers += nats_tls_link.instances.map do |instance|
-        NatsPeer.new(instance.id, nats_tls_link.p("nats.hostname"), nats_tls_link.p("nats.cluster_port"), nats_tls_link.p("nats.user"), nats_tls_link.p("nats.password"))
+        NatsPeer.new(instance.id, nats_tls_link.p("nats.hostname"), nats_tls_link.p("nats.cluster_port"), nats_tls_link_user, nats_tls_link_password)
       end
     end
   end
@@ -56,11 +76,13 @@ debug: <%= p("nats.debug") %>
 trace: <%= p("nats.trace") %>
 logtime: true
 
+<%- if nats_user and nats_password -%>
 authorization {
-  user: "<%= p("nats.user") %>"
-  password: "<%= p("nats.password") %>"
+  user: "<%= nats_user %>"
+  password: "<%= nats_password %>"
   timeout: <%= p("nats.authorization_timeout") %>
 }
+<%- end -%>
 
 tls {
   ca_file: "/var/vcap/jobs/nats-tls/config/external_tls/ca.pem"
@@ -82,11 +104,13 @@ cluster {
   host: "<%= spec.address %>"
   port: <%= p("nats.cluster_port") %>
 
+<%- if nats_user and nats_password -%>
   authorization {
-    user: "<%= p("nats.user") %>"
-    password: "<%= p("nats.password") %>"
+    user: "<%= nats_user %>"
+    password: "<%= nats_password %>"
     timeout: <%= p("nats.authorization_timeout") %>
   }
+<%- end -%>
 
   <% if p("nats.internal.tls.enabled") %>
   tls {

--- a/spec/nats-tls/nats_tls_config_spec.rb
+++ b/spec/nats-tls/nats_tls_config_spec.rb
@@ -315,6 +315,35 @@ cluster \{
               expect(rendered_template).to include(expected_template)
             end
           end
+          describe 'password authentication is disabled' do
+            before do
+              merged_manifest_properties['nats']['user'] = nil
+              merged_manifest_properties['nats']['password'] = nil
+            end
+
+            it 'renders the template without password authentication properties' do
+              rendered_template = template.render(merged_manifest_properties, consumes: links, spec: spec)
+unexpected_authorization = %{
+  authorization \{
+    user: "my-user"
+    password: "my-password"
+    timeout: 15
+  \}
+}
+unexpected_auth_url = %{
+  routes = \[
+
+    nats-route://my-user:my-password@meowmeowmeow.my-host:4223
+
+    nats-route://my-user:my-password@a-b-c-d.my-host:4223
+
+  \]
+}
+
+              expect(rendered_template).not_to include(unexpected_authorization)
+              expect(rendered_template).not_to include(unexpected_auth_url)
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
## What's changed
This PR allows to disable the password authentication for nats-tls.

The benefit of this feature is that authentication is already handled via the mTLS handshake, thus making the password obsolete.

The change is rather defensive and the default will remain enabled password authentication.
Since the client certificate validation is currently hard-coded, we could also simply drop the password altogether and make the config even easier (this applies only for nats-tls).

## Companion PRs for NATS clients:

gorouter (routing-release): https://github.com/cloudfoundry/routing-release/pull/244
route registar (routing-release): https://github.com/cloudfoundry/routing-release/pull/244
route emitter (diego-release): https://github.com/cloudfoundry/diego-release/pull/610
metrics discovery registrar (metrics-discovery-release): https://github.com/cloudfoundry/metrics-discovery-release/pull/14

## How to test this

1. Remove the NATS password from cf-deployment [here](https://github.com/cloudfoundry/cf-deployment/blob/main/cf-deployment.yml#L387-L388)
2. In a dev environment, merge all PRs mentioned (NATs, routing, diego, metrics-discovery)
3. Create dev releases for each bosh release and put them in the cf-deployment `releases` section
4. Upload all dev releases to bosh director
5. Deploy cf-deployment
6. Everything should work as before