### PR TITLE
allow to configure net interfaces binding

### DIFF
--- a/jobs/nats-tls/spec
+++ b/jobs/nats-tls/spec
@@ -79,6 +79,10 @@ properties:
   nats.write_deadline:
     description: "Maximum number of seconds the server will block when writing. Once this threshold is exceeded the connection will be closed and the client will be considered as Slow Consumer."
     default: "2s"
+  nats.net:
+    description: "Client listening interface, defaults to spec.address"
+  nats.cluster_host:
+    description: "Clustering listening interface, defaults to spec.address"
 
   nats.external.tls.ca:
     description: "Certificate of the CA for publisher/subscriber traffic. In PEM format."

--- a/jobs/nats-tls/templates/nats-tls.conf.erb
+++ b/jobs/nats-tls/templates/nats-tls.conf.erb
@@ -66,7 +66,7 @@
   end
 %>
 
-net: "<%= spec.address %>"
+net: "<%= p("nats.net", spec.address) %>"
 port: <%= p("nats.port") %>
 prof_port: <%= p("nats.prof_port") %>
 http: "0.0.0.0:<%= p("nats.monitor_port") %>"
@@ -101,7 +101,7 @@ tls {
 
 cluster {
   no_advertise: <%= p("nats.no_advertise") %>
-  host: "<%= spec.address %>"
+  host: "<%= p("nats.cluster_host", spec.address) %>"
   port: <%= p("nats.cluster_port") %>
 
 <%- if nats_user and nats_password -%>

--- a/jobs/nats/spec
+++ b/jobs/nats/spec
@@ -74,6 +74,10 @@ properties:
   nats.write_deadline:
     description: "Maximum number of seconds the server will block when writing. Once this threshold is exceeded the connection will be closed and the client will be considered as Slow Consumer."
     default: 2s
+  nats.net:
+    description: "Client listening interface, defaults to spec.address"
+  nats.cluster_host:
+    description: "Clustering listening interface, defaults to spec.address"
   nats.internal.tls.enabled:
     description: "Enable mutually authenticated TLS for NATS cluster-internal traffic."
     default: false

--- a/jobs/nats/templates/nats.conf.erb
+++ b/jobs/nats/templates/nats.conf.erb
@@ -46,7 +46,7 @@
   end
 %>
 
-net: "<%= spec.address %>"
+net: "<%= p("nats.net", spec.address) %>"
 port: <%= p("nats.port") %>
 prof_port: <%= p("nats.prof_port") %>
 http: "0.0.0.0:<%= p("nats.monitor_port") %>"
@@ -64,7 +64,7 @@ authorization {
 
 cluster {
   no_advertise: <%= p("nats.no_advertise") %>
-  host: "<%= spec.address %>"
+  host: "<%= p("nats.cluster_host", spec.address) %>"
   port: <%= p("nats.cluster_port") %>
 
   authorization {


### PR DESCRIPTION
In our multi-homed virtual machines setup we wanted to be able to configure NATS to listen on *all* interfaces.
The following patch allows that jointly with an ops-file such as:

```yaml
- type: replace
  path: /instance_groups/name=nats/jobs/name=nats/properties/nats/net?
  value: 0.0.0.0
- type: replace
  path: /instance_groups/name=nats/jobs/name=nats-tls/properties/nats/net?
  value: 0.0.0.0
```

Without an ops-file, the configuration stick to the previous comportment, that is to bind only on `spec.address`.