### PR TITLE
bump golang to 1.17

### DIFF
--- a/.final_builds/packages/golang-1.17-linux/index.yml
+++ b/.final_builds/packages/golang-1.17-linux/index.yml
@@ -1,0 +1,6 @@
+builds:
+  e97ed0e98fb26dd71bb101f8a1f97fe1f98073d9c50233d4c0620fa1c2b63300:
+    version: e97ed0e98fb26dd71bb101f8a1f97fe1f98073d9c50233d4c0620fa1c2b63300
+    blobstore_id: 3b48e7b9-073f-4bef-7d0c-08d296fc07fa
+    sha1: sha256:0ee71bf6c76f11723f9d91fbc9b2ef87499363a1d95ab86cee74d5f5a0fd52d9
+format-version: "2"

--- a/packages/gnatsd/spec
+++ b/packages/gnatsd/spec
@@ -2,7 +2,7 @@
 name: gnatsd
 
 dependencies:
-  - golang-1.16-linux
+  - golang-1.17-linux
 
 files:
   - go.mod

--- a/packages/golang-1-linux/spec.lock
+++ b/packages/golang-1-linux/spec.lock
@@ -1,2 +1,0 @@
-name: golang-1-linux
-fingerprint: 5b79dae188e2d5d5f7dde7df37bf9e4b6d93f798c40a18f3ed76bf7500b8a333

--- a/packages/golang-1.16-linux/spec.lock
+++ b/packages/golang-1.16-linux/spec.lock
@@ -1,2 +1,0 @@
-name: golang-1.16-linux
-fingerprint: 7e6c7fac8719810ab06b4833c33f17d563f4b438c06090ff7eda4b8f755269a1

--- a/packages/golang-1.17-linux/spec.lock
+++ b/packages/golang-1.17-linux/spec.lock
@@ -1,0 +1,2 @@
+name: golang-1.17-linux
+fingerprint: e97ed0e98fb26dd71bb101f8a1f97fe1f98073d9c50233d4c0620fa1c2b63300

--- a/packages/nats-smoke/packaging
+++ b/packages/nats-smoke/packaging
@@ -6,7 +6,7 @@ mkdir -p ${BOSH_INSTALL_TARGET}/src
 mv * ${BOSH_INSTALL_TARGET}/src
 mv ${BOSH_INSTALL_TARGET}/src .
 
-source /var/vcap/packages/golang-1-linux/bosh/compile.env
+source /var/vcap/packages/golang-*-linux/bosh/compile.env
 export GOBIN=${BOSH_INSTALL_TARGET}/bin
 
 pushd src

--- a/packages/nats-smoke/spec
+++ b/packages/nats-smoke/spec
@@ -2,7 +2,7 @@
 name: nats-smoke
 
 dependencies:
-  - golang-1.16-linux
+  - golang-1.17-linux
 
 files:
   - go.mod

--- a/src/go.mod
+++ b/src/go.mod
@@ -1,13 +1,18 @@
 module code.cloudfoundry.org/nats-release
 
-go 1.16
+go 1.17
 
 replace github.com/nats-io/gnatsd => github.com/nats-io/gnatsd v1.4.1
 
 require (
 	code.cloudfoundry.org/tlsconfig v0.0.0-20200131000646-bbe0f8da39b3
-	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/nats-io/gnatsd v1.4.1
 	github.com/nats-io/go-nats v1.4.0
+)
+
+require (
+	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/nats-io/nuid v1.0.1 // indirect
+	golang.org/x/crypto v0.0.0-20181127143415-eb0de9b17e85 // indirect
+	golang.org/x/sys v0.0.0-20181128092732-4ed8d59d0b35 // indirect
 )

--- a/src/vendor/code.cloudfoundry.org/tlsconfig/go.mod
+++ b/src/vendor/code.cloudfoundry.org/tlsconfig/go.mod
@@ -1,5 +1,0 @@
-module code.cloudfoundry.org/tlsconfig
-
-require github.com/square/certstrap v1.2.0
-
-go 1.13

--- a/src/vendor/code.cloudfoundry.org/tlsconfig/go.sum
+++ b/src/vendor/code.cloudfoundry.org/tlsconfig/go.sum
@@ -1,9 +1,0 @@
-github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/howeyc/gopass v0.0.0-20170109162249-bf9dde6d0d2c/go.mod h1:lADxMC39cJJqL93Duh1xhAs4I2Zs8mKS89XWXFGp9cs=
-github.com/square/certstrap v1.2.0 h1:ecgyABrbFLr8jSbOC6oTBmBek0t/HqtgrMUZCPuyfdw=
-github.com/square/certstrap v1.2.0/go.mod h1:CUHqV+fxJW0Y5UQFnnbYwQ7bpKXO1AKbic9g73799yw=
-github.com/urfave/cli v1.21.0/go.mod h1:lxDj6qX9Q6lWQxIrbrT0nwecwUtRnhVZAJjJZrVUZZQ=
-golang.org/x/crypto v0.0.0-20181127143415-eb0de9b17e85/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
-golang.org/x/sys v0.0.0-20181128092732-4ed8d59d0b35/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/src/vendor/modules.txt
+++ b/src/vendor/modules.txt
@@ -1,8 +1,8 @@
 # code.cloudfoundry.org/tlsconfig v0.0.0-20200131000646-bbe0f8da39b3
-## explicit
+## explicit; go 1.13
 code.cloudfoundry.org/tlsconfig
 # github.com/golang/protobuf v1.5.2
-## explicit
+## explicit; go 1.9
 # github.com/nats-io/gnatsd v1.4.1 => github.com/nats-io/gnatsd v1.4.1
 ## explicit
 github.com/nats-io/gnatsd
@@ -19,9 +19,11 @@ github.com/nats-io/go-nats/util
 ## explicit
 github.com/nats-io/nuid
 # golang.org/x/crypto v0.0.0-20181127143415-eb0de9b17e85
+## explicit
 golang.org/x/crypto/bcrypt
 golang.org/x/crypto/blowfish
 # golang.org/x/sys v0.0.0-20181128092732-4ed8d59d0b35
+## explicit
 golang.org/x/sys/windows
 golang.org/x/sys/windows/registry
 golang.org/x/sys/windows/svc


### PR DESCRIPTION
- Removes unnecessary bosh packages `golang-1.16-linux` and `golang-1-linux` in favor of explicit `golang-1.17-linux`