### PR TITLE
Replace NATS TLS monit "failed host" healthcheck with healthcheck process

### DIFF
--- a/jobs/nats-tls/monit
+++ b/jobs/nats-tls/monit
@@ -1,8 +1,14 @@
 check process nats-tls
   with pidfile /var/vcap/sys/run/bpm/nats-tls/nats-tls.pid
-  start program "/var/vcap/jobs/bpm/bin/bpm start nats-tls"
-  stop program "/var/vcap/jobs/bpm/bin/bpm stop nats-tls"
+  start program "/var/vcap/jobs/bpm/bin/bpm start nats-tls -p nats-tls"
+  stop program "/var/vcap/jobs/bpm/bin/bpm stop nats-tls -p nats-tls"
   group vcap
   if totalmem > 500 Mb for 2 cycles then alert
   if totalmem > 3000 Mb then restart
-  if failed host <%= spec.address %> port <%= p("nats.port") %> type tcp then alert
+
+check process nats-tls-healthcheck
+  with pidfile /var/vcap/sys/run/bpm/nats-tls/healthcheck.pid
+  start program "/var/vcap/jobs/bpm/bin/bpm start nats-tls -p healthcheck"
+  stop program "/var/vcap/jobs/bpm/bin/bpm stop nats-tls -p healthcheck"
+  depends on nats-tls
+  group vcap

--- a/jobs/nats-tls/spec
+++ b/jobs/nats-tls/spec
@@ -16,8 +16,12 @@ templates:
   external_tls/certificate.pem.erb: config/external_tls/certificate.pem
   external_tls/private_key.pem.erb: config/external_tls/private_key.pem
 
+  client_tls/certificate.pem.erb: config/client_tls/certificate.pem
+  client_tls/private_key.pem.erb: config/client_tls/private_key.pem
+
 packages:
   - gnatsd
+  - nats-tls-healthcheck
 
 provides:
 - name: nats-tls
@@ -96,3 +100,8 @@ properties:
     description: "Certificate for cluster-internal traffic. In PEM format."
   nats.internal.tls.private_key:
     description: "Private key for cluster-internal traffic. In PEM format."
+
+  nats.client.tls.certificate:
+    description: "The PEM-encoded certificate to use for verifying the TLS connection to the server (used for local healthchecks)."
+  nats.client.tls.private_key:
+    description: "The PEM-encoded private key to use for verifying the TLS connection to the server (used for local healthchecks)."

--- a/jobs/nats-tls/templates/bpm.erb.yml
+++ b/jobs/nats-tls/templates/bpm.erb.yml
@@ -1,9 +1,45 @@
----
-processes:
-- name: nats-tls
-  limits:
-    open_files: 100000
-  executable: /var/vcap/packages/gnatsd/bin/gnatsd
-  args:
-  - -c
-  - "/var/vcap/jobs/nats-tls/config/nats-tls.conf"
+<%=
+
+  healthcheck_auth_args = []
+  if_p('nats.user') do |user|
+    healthcheck_auth_args += ['--user', user]
+  end
+
+  if_p('nats.password') do |password|
+    healthcheck_auth_args += ['--password', password]
+  end
+
+  YAML.dump({
+    'processes' => [
+      {
+        'name' => 'nats-tls',
+        'limits' => {
+          'open_files' => 100000
+        },
+        'executable' => '/var/vcap/packages/gnatsd/bin/gnatsd',
+        'args' => [
+          '-c',
+          '/var/vcap/jobs/nats-tls/config/nats-tls.conf'
+        ]
+      },
+      {
+        'name' => 'healthcheck',
+        'executable' => '/var/vcap/packages/nats-tls-healthcheck/bin/nats-tls-healthcheck',
+        'args' => [
+          '--address',
+          spec.address,
+          '--port',
+          p('nats.port'),
+          '--server-ca',
+          '/var/vcap/jobs/nats-tls/config/external_tls/ca.pem',
+          '--server-hostname',
+          p('nats.hostname'),
+          '--client-certificate',
+          '/var/vcap/jobs/nats-tls/config/client_tls/certificate.pem',
+          '--client-private-key',
+          '/var/vcap/jobs/nats-tls/config/client_tls/private_key.pem'
+        ] + healthcheck_auth_args
+      }
+    ]
+  })
+%>

--- a/jobs/nats-tls/templates/client_tls/certificate.pem.erb
+++ b/jobs/nats-tls/templates/client_tls/certificate.pem.erb
@@ -1,0 +1,1 @@
+<%= p("nats.client.tls.certificate") %>

--- a/jobs/nats-tls/templates/client_tls/certificate.pem.erb
+++ b/jobs/nats-tls/templates/client_tls/certificate.pem.erb
@@ -1,1 +1,7 @@
+<% if p("nats.client.tls.certificate", false) -%>
 <%= p("nats.client.tls.certificate") %>
+<%
+  else
+    raise "nats.client.tls.certificate not provided in nats-tls job properties"
+  end
+-%>

--- a/jobs/nats-tls/templates/client_tls/private_key.pem.erb
+++ b/jobs/nats-tls/templates/client_tls/private_key.pem.erb
@@ -1,0 +1,1 @@
+<%= p("nats.client.tls.private_key") %>

--- a/jobs/nats-tls/templates/client_tls/private_key.pem.erb
+++ b/jobs/nats-tls/templates/client_tls/private_key.pem.erb
@@ -1,1 +1,7 @@
+<% if p("nats.client.tls.private_key", false) -%>
 <%= p("nats.client.tls.private_key") %>
+<%
+  else
+    raise "nats.client.tls.private_key not provided in nats-tls job properties"
+  end
+-%>

--- a/packages/nats-tls-healthcheck/packaging
+++ b/packages/nats-tls-healthcheck/packaging
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -ex
+
+mkdir -p ${BOSH_INSTALL_TARGET}/src
+mv * ${BOSH_INSTALL_TARGET}/src
+mv ${BOSH_INSTALL_TARGET}/src .
+
+export GOBIN=${BOSH_INSTALL_TARGET}/bin
+mkdir -p "${GOBIN}"
+
+source /var/vcap/packages/golang-*-linux/bosh/compile.env
+
+pushd "src"
+  go build -o "${GOBIN}/nats-tls-healthcheck" code.cloudfoundry.org/nats-release/nats-tls-healthcheck
+popd

--- a/packages/nats-tls-healthcheck/spec
+++ b/packages/nats-tls-healthcheck/spec
@@ -1,0 +1,12 @@
+---
+name: nats-tls-healthcheck
+
+dependencies:
+  - golang-1.17-linux
+
+files:
+  - go.mod
+  - go.sum
+  - vendor/modules.txt
+  - vendor/**/*
+  - nats-tls-healthcheck/*.go

--- a/spec/nats-tls/nats_tls_config_spec.rb
+++ b/spec/nats-tls/nats_tls_config_spec.rb
@@ -439,7 +439,52 @@ unexpected_auth_url = %{
             end
           end
         end
-     end
+
+        describe 'config/client_tls/certificate.pem' do
+          let(:template) { job.template('config/client_tls/certificate.pem') }
+
+          it 'renders the certificate correctly' do
+            output = YAML.load(template.render(merged_manifest_properties, consumes: links, spec: spec))
+            expect(output).to eq('client-tls-cert')
+          end
+
+          describe 'when a client certificate is not provided in the manifest' do
+            let(:merged_manifest_properties_without_certificate) do
+              merged_manifest_properties.tap do |props|
+                props['nats']['client']['tls'].delete('certificate')
+              end
+            end
+
+            it 'fails with a meaningful error message' do
+              expect do
+                YAML.load(template.render(merged_manifest_properties_without_certificate, consumes: links, spec: spec))
+              end.to raise_error(/nats.client.tls.certificate not provided in nats-tls job properties/)
+            end
+          end
+        end
+        describe 'config/client_tls/private_key.pem' do
+          let(:template) { job.template('config/client_tls/private_key.pem') }
+
+          it 'renders the private key correctly' do
+            output = YAML.load(template.render(merged_manifest_properties, consumes: links, spec: spec))
+            expect(output).to eq('client-tls-key')
+          end
+
+          describe 'when a client private_key is not provided in the manifest' do
+            let(:merged_manifest_properties_without_private_key) do
+              merged_manifest_properties.tap do |props|
+                props['nats']['client']['tls'].delete('private_key')
+              end
+            end
+
+            it 'fails with a meaningful error message' do
+              expect do
+                YAML.load(template.render(merged_manifest_properties_without_private_key, consumes: links, spec: spec))
+              end.to raise_error(/nats.client.tls.private_key not provided in nats-tls job properties/)
+            end
+          end
+        end
+      end
     end
   end
 end

--- a/src/nats-tls-healthcheck/.gitignore
+++ b/src/nats-tls-healthcheck/.gitignore
@@ -1,0 +1,1 @@
+nats-tls-healthcheck

--- a/src/nats-tls-healthcheck/main.go
+++ b/src/nats-tls-healthcheck/main.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"time"
+
+	"code.cloudfoundry.org/tlsconfig"
+
+	nats "github.com/nats-io/go-nats"
+)
+
+// Simple healthcheck app that verifies a connection can be
+// made to the locally-running NATS server every ten seconds
+
+func main() {
+	address := flag.String("address", "", "")
+	port := flag.String("port", "", "")
+	user := flag.String("user", "", "")
+	password := flag.String("password", "", "")
+	serverCAPath := flag.String("server-ca", "", "")
+	serverHostname := flag.String("server-hostname", "", "")
+	clientCertificatePath := flag.String("client-certificate", "", "")
+	clientKeyPath := flag.String("client-private-key", "", "")
+
+	flag.Parse()
+
+	tlsConfig, err := tlsconfig.Build(
+		tlsconfig.WithInternalServiceDefaults(),
+		tlsconfig.WithIdentityFromFile(*clientCertificatePath, *clientKeyPath),
+	).Client(
+		tlsconfig.WithAuthorityFromFile(*serverCAPath),
+	)
+	if err != nil {
+		log.Fatalf("failed to build tls configuration: %s\n", err)
+	}
+	tlsConfig.ServerName = *serverHostname
+
+	connectionOptions := []nats.Option{
+		nats.Secure(tlsConfig),
+		nats.NoReconnect(),
+	}
+
+	if *user != "" && *password != "" {
+		connectionOptions = append(connectionOptions, nats.UserInfo(*user, *password))
+	}
+
+	for {
+		connection, err := nats.Connect(
+			fmt.Sprintf("nats://%s:%s", *address, *port),
+			connectionOptions...,
+		)
+		if err != nil {
+			log.Fatalf("failed to connect to NATS server: %s", err)
+		}
+		connection.Close()
+
+		time.Sleep(10 * time.Second)
+	}
+}


### PR DESCRIPTION
Replaces the NATS TLS monit job "failed host" healthcheck with a [cloud-controller-style](https://github.com/cloudfoundry/capi-release/blob/develop/jobs/cloud_controller_ng/monit#L10-L16) dedicated healthcheck process following [the suggestion](https://github.com/cloudfoundry/nats-release/pull/37#issuecomment-962053778) by @geofffranks in #37.

This avoids misleading TLS handshake errors in the NATS logs caused by the monit TCP test (see #32, #34, #37). It also provides a more rigorous healthcheck because as well as testing that the server is listening on a given port, the new check requires that the server and client TLS configuration is correct, and that the server is speaking the NATS protocol.

Unfortunately this now requires the client TLS certificate and private keys in the job spec as the new healthcheck process requires them to establish a connection to the server.

I also changed `jobs/nats-tls/templates/bpm.erb.yml` to use `YAML.dump`, as this seemed like the safest way to introduce interpolated variables such as the nats password (which may contain special characters) which need to be passed to the new healthcheck binary, and also matches the [pattern](https://github.com/cloudfoundry/capi-release/blob/develop/jobs/cloud_controller_ng/templates/bpm.yml.erb) used by the cloud controller.

