### PR TITLE
Introduce nats.auth_required for nats-tls

### DIFF
--- a/jobs/nats-tls/spec
+++ b/jobs/nats-tls/spec
@@ -52,6 +52,9 @@ properties:
   nats.hostname:
     description: "Hostname for nats cluster. Set this to the value of your bosh-dns-alias."
     example: "nats.service.cf.internal"
+  nats.auth_required:
+    desription: "Use username and password for authorization for NATS cluster-internal traffic as well for external traffic"
+    default: true
   nats.port:
     description: "The port for the NATS server to listen on."
     default: 4224

--- a/jobs/nats-tls/templates/nats-tls.conf.erb
+++ b/jobs/nats-tls/templates/nats-tls.conf.erb
@@ -24,17 +24,13 @@
   nats_peers = nil
   nats_user = nil
   nats_password = nil
-  nats_auth_required = true
   if_p("nats.user") do |user|
     nats_user = user
   end
   if_p("nats.password") do |password|
     nats_password = password
   end
-  if_p("nats.auth_required") do |auth_required|
-    nats_auth_required = auth_required
-  end
-
+  nats_auth_required = p("nats.auth_required")
   if_p("nats.machines") do |ips|
     nats_peers = ips.map do |ip|
       NatsPeer.new(nil, ip, p("nats.cluster_port"), nats_user, nats_password)

--- a/jobs/nats-tls/templates/nats-tls.conf.erb
+++ b/jobs/nats-tls/templates/nats-tls.conf.erb
@@ -24,11 +24,15 @@
   nats_peers = nil
   nats_user = nil
   nats_password = nil
+  nats_auth_required = true
   if_p("nats.user") do |user|
     nats_user = user
   end
   if_p("nats.password") do |password|
     nats_password = password
+  end
+  if_p("nats.auth_required") do |auth_required|
+    nats_auth_required = auth_required
   end
 
   if_p("nats.machines") do |ips|
@@ -76,7 +80,7 @@ debug: <%= p("nats.debug") %>
 trace: <%= p("nats.trace") %>
 logtime: true
 
-<%- if nats_user and nats_password -%>
+<%- if nats_auth_required and nats_user and nats_password -%>
 authorization {
   user: "<%= nats_user %>"
   password: "<%= nats_password %>"
@@ -104,7 +108,7 @@ cluster {
   host: "<%= spec.address %>"
   port: <%= p("nats.cluster_port") %>
 
-<%- if nats_user and nats_password -%>
+  <%- if nats_auth_required and nats_user and nats_password -%>
   authorization {
     user: "<%= nats_user %>"
     password: "<%= nats_password %>"

--- a/spec/nats-tls/nats_tls_config_spec.rb
+++ b/spec/nats-tls/nats_tls_config_spec.rb
@@ -359,13 +359,13 @@ unexpected_auth_url = %{
   
             it 'renders the template without password authentication properties' do
               rendered_template = template.render(merged_manifest_properties, consumes: links, spec: spec)
-  unexpected_authorization = %{
+unexpected_authorization = %{
   authorization \{
     user: "my-user"
     password: "my-password"
     timeout: 15
   \}
-  }
+}
   
               expect(rendered_template).not_to include(unexpected_authorization)
             end

--- a/spec/nats-tls/nats_tls_config_spec.rb
+++ b/spec/nats-tls/nats_tls_config_spec.rb
@@ -351,6 +351,25 @@ unexpected_auth_url = %{
               expect(rendered_template).not_to include(unexpected_auth_url)
             end
           end
+          
+          describe 'password authentication is disabled due to auth_required = false' do
+            before do
+              merged_manifest_properties['nats']['auth_required'] = false
+            end
+  
+            it 'renders the template without password authentication properties' do
+              rendered_template = template.render(merged_manifest_properties, consumes: links, spec: spec)
+  unexpected_authorization = %{
+  authorization \{
+    user: "my-user"
+    password: "my-password"
+    timeout: 15
+  \}
+  }
+  
+              expect(rendered_template).not_to include(unexpected_authorization)
+            end
+          end
         end
 
         describe 'config/bpm.yml' do


### PR DESCRIPTION
Currently the only way to disable authentication via username and password is to remove the respective properties. This can however lead to "nats: Authorization Violation" issues between updated and not-yet-updated NATS servers and clients during update process. We therefore propose a safe way to deactivate username/password authentication by implementing a separate “auth_required” property for nats-tls.
