### PR TITLE
Change nats-wrapper to use a DialTimeout when connecting to nats to prevent long startup delays

### DIFF
--- a/src/code.cloudfoundry.org/nats-v2-migrate/natsinfo/nats_version.go
+++ b/src/code.cloudfoundry.org/nats-v2-migrate/natsinfo/nats_version.go
@@ -60,11 +60,13 @@ func GetMajorVersion(natsMachineUrl string) (int, error) {
 func connectWithRetry(natsMachineUrl string) (conn net.Conn, err error) {
 	attempts := int(NATSConnectionTimeout / NATSConnectionRetryInterval)
 	for i := 0; i < attempts; i++ {
-		conn, err = net.Dial("tcp", natsMachineUrl)
+		startTime := time.Now()
+		conn, err = net.DialTimeout("tcp", natsMachineUrl, NATSConnectionRetryInterval)
 		if err == nil {
 			return conn, nil
 		}
-		time.Sleep(NATSConnectionRetryInterval)
+		elapsedTime := time.Now().Sub(startTime)
+		time.Sleep(NATSConnectionRetryInterval - elapsedTime)
 	}
 	return nil, err
 }

--- a/src/code.cloudfoundry.org/nats-v2-migrate/natsinfo/nats_version.go
+++ b/src/code.cloudfoundry.org/nats-v2-migrate/natsinfo/nats_version.go
@@ -11,7 +11,8 @@ import (
 )
 
 const (
-	NATSConnectionTimeout       = 10 * time.Second
+	NATSConnectionTimeout       = 6 * time.Second
+	NATSConnectionRetries       = 10
 	NATSConnectionRetryInterval = 1 * time.Second
 )
 
@@ -58,15 +59,12 @@ func GetMajorVersion(natsMachineUrl string) (int, error) {
 }
 
 func connectWithRetry(natsMachineUrl string) (conn net.Conn, err error) {
-	attempts := int(NATSConnectionTimeout / NATSConnectionRetryInterval)
-	for i := 0; i < attempts; i++ {
-		startTime := time.Now()
-		conn, err = net.DialTimeout("tcp", natsMachineUrl, NATSConnectionRetryInterval)
+	for i := 0; i < NATSConnectionRetries; i++ {
+		conn, err = net.DialTimeout("tcp", natsMachineUrl, NATSConnectionTimeout)
 		if err == nil {
 			return conn, nil
 		}
-		elapsedTime := time.Now().Sub(startTime)
-		time.Sleep(NATSConnectionRetryInterval - elapsedTime)
+		time.Sleep(NATSConnectionRetryInterval)
 	}
 	return nil, err
 }


### PR DESCRIPTION
What
----

When connecting to the nats cluster, the nats-wrapper should use a DialTimeout. Connections to servers that are offline and on a different subnet can take minutes to timeout.

Why
----

This pull request addresses the issue concerning [long delays when starting the nats-server](https://github.com/cloudfoundry/nats-release/issues/49).

Testing
----

Before fix:

```
vcap      4701     1  0 08:33 ?        00:00:00 /var/vcap/packages/bpm/bin/tini -w -s -- /var/vcap/packages/nats-v2-migrate/bin/nats-wrapper --config-file /var/vcap/jobs/nats-tls/config/migrator-config.json
vcap      4719  4701  0 08:33 ?        00:00:00 /var/vcap/packages/nats-v2-migrate/bin/nats-wrapper --config-file /var/vcap/jobs/nats-tls/config/migrator-config.json
vcap      7724  4719  0 08:55 ?        00:00:00 /var/vcap/packages/nats-server/bin/nats-server -c /var/vcap/jobs/nats-tls/config/nats-tls.conf
```

```
{"timestamp":"2023-01-06T08:33:36.582791600Z","level":"info","source":"nats-migrate-server","message":"nats-migrate-server.signalled-nats","data":{}}
{"timestamp":"2023-01-06T08:55:28.679197840Z","level":"error","source":"nats-migrate-server","message":"nats-migrate-server.ignoring-machine-due-to-connection-error","data":{"error":"Error connecting: dial tcp 10.1.16.212:4224: connect: connection timed out","url":"10.1.16.212:4224"}}
{"timestamp":"2023-01-06T08:55:28.680106937Z","level":"info","source":"nats-migrate-server","message":"nats-migrate-server.started-nats","data":{}}
{"timestamp":"2023-01-06T08:55:28.683615963Z","level":"info","source":"nats-migrate-server","message":"nats-migrate-server.started","data":{}}
```

~22 minute delayed start up.

After fix:

```
vcap      1800     1  0 09:18 ?        00:00:00 /var/vcap/packages/bpm/bin/tini -w -s -- /var/vcap/packages/nats-v2-migrate/bin/nats-wrapper --config-file /var/vcap/jobs/nats-tls/config/migrator-config.json
vcap      1820  1800  0 09:18 ?        00:00:00 /var/vcap/packages/nats-v2-migrate/bin/nats-wrapper --config-file /var/vcap/jobs/nats-tls/config/migrator-config.json
vcap      1897  1820  0 09:18 ?        00:00:00 /var/vcap/packages/nats-server/bin/nats-server -c /var/vcap/jobs/nats-tls/config/nats-tls.conf
```

```
{"timestamp":"2023-01-09T09:18:26.772419516Z","level":"info","source":"nats-migrate-server","message":"nats-migrate-server.signalled-nats","data":{}}
{"timestamp":"2023-01-09T09:18:37.940832923Z","level":"error","source":"nats-migrate-server","message":"nats-migrate-server.ignoring-machine-due-to-connection-error","data":{"error":"Error connecting: dial tcp 10.1.16.212:4224: i/o timeout","url":"10.1.16.212:4224"}}
{"timestamp":"2023-01-09T09:18:37.941811320Z","level":"info","source":"nats-migrate-server","message":"nats-migrate-server.started-nats","data":{}}
{"timestamp":"2023-01-09T09:18:37.944830463Z","level":"info","source":"nats-migrate-server","message":"nats-migrate-server.started","data":{}}
```

~10 second delayed startup.

Concerns
----

A connection timeout of 1 second is quite aggressive. It is possible users with badly performing networks or extremely large latencies may get issues.

Alternatives
----

We could try to split out the constants so we have a separate connection timeout. Something like the following:

```
const (
	NATSConnectionMaxTimeout       = 10 * time.Second
	NATSConnectionTimeout              = 1 * time.Second
	NATSConnectionRetryInterval      = 1 * time.Second
)

func connectWithRetry(natsMachineUrl string) (conn net.Conn, err error) {
	var conn net.Conn
	var err error
	elapsed := time.Duration(0)
	for {
		start := time.Now()
		conn, err = net.DialTimeout("tcp", natsMachineUrl, NATSConnectionTimeout)
		elapsed += time.Since(start)
		if err == nil || elapsed > NATSConnectionMaxTimeout {
			break
		}
		time.Sleep(NATSConnectionRetryInterval - time.Since(start))
	}
	return conn, err
}
```

This would allow us to manipulate the overall timeout and connection timeouts more freely.