### PR TITLE
add extra checks to confirm that nats server is up (for test flakiness)

### DIFF
--- a/src/code.cloudfoundry.org/nats-v2-migrate/integration/migrate_test.go
+++ b/src/code.cloudfoundry.org/nats-v2-migrate/integration/migrate_test.go
@@ -156,6 +156,9 @@ var _ = Describe("Migrate", func() {
 			It("retries with the timeout", func() {
 				Consistently(migrateSess).WithTimeout(2 * time.Second).ShouldNot(gexec.Exit())
 				natsRunner.Start()
+				version, err := natsinfo.GetMajorVersion(natsRunner.Addr())
+				Expect(err).NotTo(HaveOccurred())
+				Expect(version).To(Equal(2))
 				Eventually(migrateSess).Should(gexec.Exit(0))
 			})
 		})


### PR DESCRIPTION
The flaking test in question runs the migration script with the nats server initially down. Once the nats server is up, the migration should succeed.

I believe that we are not waiting long enough before asserting that the migration has succeeded. Adding extra checks on the server before asserting that the script has exited.