### PR TITLE
feat: make nats memory limits configurable

### DIFF
--- a/jobs/nats-tls/monit
+++ b/jobs/nats-tls/monit
@@ -1,10 +1,20 @@
+<%-
+memory_limit_alert = p("nats.mem_limit.alert")
+if ! memory_limit_alert.match(/[0-9]+ (B|KB|MB|GB|\%)/)
+  abort("Bad 'nats.mem_limit.alert' setting: #{memory_limit_alert}. Format is: <number> B|KB|MB|GB|\%")
+end
+memory_limit_restart = p("nats.mem_limit.restart")
+if ! memory_limit_restart.match(/[0-9]+ (B|KB|MB|GB|\%)/)
+  abort("Bad 'nats.mem_limit.restart' setting: #{memory_limit_restart}. Format is: <number> B|KB|MB|GB|\%")
+end
+-%>
 check process nats-tls-wrapper
   with pidfile /var/vcap/sys/run/bpm/nats-tls/nats-tls-wrapper.pid
   start program "/var/vcap/jobs/bpm/bin/bpm start nats-tls -p nats-tls-wrapper"
   stop program "/var/vcap/jobs/bpm/bin/bpm stop nats-tls -p nats-tls-wrapper"
   group vcap
-  if totalmem > 500 Mb for 2 cycles then alert
-  if totalmem > 3000 Mb then restart
+  if totalmem > <%= p("nats.mem_limit.alert") %> for 2 cycles then alert
+  if totalmem > <%= p("nats.mem_limit.restart") %> then restart
 
 check process nats-tls-healthcheck
   with pidfile /var/vcap/sys/run/bpm/nats-tls/healthcheck.pid

--- a/jobs/nats-tls/spec
+++ b/jobs/nats-tls/spec
@@ -126,3 +126,10 @@ properties:
   nats.fail_deployment_if_v1:
     description: "Fail the deployment in post-start if nats instances are on v1."
     default: false
+
+  nats.mem_limit.alert:
+    description: "Raise alert if total memory consumed by nats is larger than this. Format: <number> <B|KB|MB|GB|%>"
+    default: "500 MB"
+  nats.mem_limit.restart:
+    description: "Restart nats if total memory consumed is larger than this. Format: <number> <B|KB|MB|GB|%>"
+    default: "3000 MB"

--- a/spec/nats-tls/monit_spec.rb
+++ b/spec/nats-tls/monit_spec.rb
@@ -1,0 +1,182 @@
+require 'rspec'
+require 'bosh/template/test'
+require 'yaml'
+require 'json'
+
+module Bosh::Template::Test
+  describe 'monit' do
+    describe 'template rendering' do
+      let(:release_path) { File.join(File.dirname(__FILE__), '../..') }
+      let(:release) { ReleaseDir.new(release_path) }
+      let(:job) {release.job('nats-tls')}
+      let(:job_path) { job.instance_variable_get(:@job_path) }
+      let(:spec) { job.instance_variable_get(:@spec) }
+      let(:template) { Template.new(spec, File.join(job_path, 'monit')) }
+
+      let(:merged_manifest_properties) do
+        {
+          'nats' => {
+            'mem_limit' => {
+              'alert' => '500 MB',
+              'restart' => '3000 MB'
+            }
+          }
+        }
+      end
+
+      describe 'defaults' do
+        it 'renders the template with the provided manifest properties' do
+          rendered_template = template.render({})
+          expect(rendered_template).to include("if totalmem > 500 MB for 2 cycles then alert")
+          expect(rendered_template).to include("if totalmem > 3000 MB then restart")
+        end
+      end
+      describe 'alert limits' do
+        describe 'set B limit on alert' do
+          before do
+            merged_manifest_properties['nats']['mem_limit']['alert'] = '100 B'
+          end
+          it 'renders the template with the provided manifest properties' do
+            rendered_template = template.render(merged_manifest_properties)
+            expect(rendered_template).to include("if totalmem > 100 B for 2 cycles then alert")
+            expect(rendered_template).to include("if totalmem > 3000 MB then restart")
+          end
+        end
+        describe 'set KB limit on alert' do
+          before do
+            merged_manifest_properties['nats']['mem_limit']['alert'] = '100 KB'
+          end
+          it 'renders the template with the provided manifest properties' do
+            rendered_template = template.render(merged_manifest_properties)
+            expect(rendered_template).to include("if totalmem > 100 KB for 2 cycles then alert")
+            expect(rendered_template).to include("if totalmem > 3000 MB then restart")
+          end
+        end
+        describe 'set MB limit on alert' do
+          before do
+            merged_manifest_properties['nats']['mem_limit']['alert'] = '100 MB'
+          end
+          it 'renders the template with the provided manifest properties' do
+            rendered_template = template.render(merged_manifest_properties)
+            expect(rendered_template).to include("if totalmem > 100 MB for 2 cycles then alert")
+            expect(rendered_template).to include("if totalmem > 3000 MB then restart")
+          end
+        end
+        describe 'set GB limit on alert' do
+          before do
+            merged_manifest_properties['nats']['mem_limit']['alert'] = '100 GB'
+          end
+          it 'renders the template with the provided manifest properties' do
+            rendered_template = template.render(merged_manifest_properties)
+            expect(rendered_template).to include("if totalmem > 100 GB for 2 cycles then alert")
+            expect(rendered_template).to include("if totalmem > 3000 MB then restart")
+          end
+        end
+        describe 'set % limit on alert' do
+          before do
+            merged_manifest_properties['nats']['mem_limit']['alert'] = '100 %'
+          end
+          it 'renders the template with the provided manifest properties' do
+            rendered_template = template.render(merged_manifest_properties)
+            expect(rendered_template).to include("if totalmem > 100 % for 2 cycles then alert")
+            expect(rendered_template).to include("if totalmem > 3000 MB then restart")
+          end
+        end
+      end
+      describe 'restart limits' do
+        describe 'set B limit on restart' do
+          before do
+            merged_manifest_properties['nats']['mem_limit']['restart'] = '100 B'
+          end
+          it 'renders the template with the provided manifest properties' do
+            rendered_template = template.render(merged_manifest_properties)
+            expect(rendered_template).to include("if totalmem > 500 MB for 2 cycles then alert")
+            expect(rendered_template).to include("if totalmem > 100 B then restart")
+          end
+        end
+        describe 'set KB limit on restart' do
+          before do
+            merged_manifest_properties['nats']['mem_limit']['restart'] = '100 KB'
+          end
+          it 'renders the template with the provided manifest properties' do
+            rendered_template = template.render(merged_manifest_properties)
+            expect(rendered_template).to include("if totalmem > 500 MB for 2 cycles then alert")
+            expect(rendered_template).to include("if totalmem > 100 KB then restart")
+          end
+        end
+        describe 'set MB limit on restart' do
+          before do
+            merged_manifest_properties['nats']['mem_limit']['restart'] = '100 MB'
+          end
+          it 'renders the template with the provided manifest properties' do
+            rendered_template = template.render(merged_manifest_properties)
+            expect(rendered_template).to include("if totalmem > 500 MB for 2 cycles then alert")
+            expect(rendered_template).to include("if totalmem > 100 MB then restart")
+          end
+        end
+        describe 'set GB limit on restart' do
+          before do
+            merged_manifest_properties['nats']['mem_limit']['restart'] = '100 GB'
+          end
+          it 'renders the template with the provided manifest properties' do
+            rendered_template = template.render(merged_manifest_properties)
+            expect(rendered_template).to include("if totalmem > 500 MB for 2 cycles then alert")
+            expect(rendered_template).to include("if totalmem > 100 GB then restart")
+          end
+        end
+        describe 'set % limit on restart' do
+          before do
+            merged_manifest_properties['nats']['mem_limit']['restart'] = '100 %'
+          end
+          it 'renders the template with the provided manifest properties' do
+            rendered_template = template.render(merged_manifest_properties)
+            expect(rendered_template).to include("if totalmem > 500 MB for 2 cycles then alert")
+            expect(rendered_template).to include("if totalmem > 100 % then restart")
+          end
+        end
+      end
+      describe 'errors' do
+        describe 'set bad limit on alert' do
+          before do
+            merged_manifest_properties['nats']['mem_limit']['alert'] = '100 potatoes'
+          end
+          it 'raises an error' do
+            expect do
+              template.render(merged_manifest_properties)
+            end.to raise_error(/Bad 'nats.mem_limit.alert' setting: 100 potatoes. Format is: <number> B|KB|MB|GB|%/)
+          end
+        end
+        describe 'set non-integer limit on alert' do
+          before do
+            merged_manifest_properties['nats']['mem_limit']['alert'] = 'mashed potatoes'
+          end
+          it 'raises an error' do
+            expect do
+              template.render(merged_manifest_properties)
+            end.to raise_error(/Bad 'nats.mem_limit.alert' setting: mashed potatoes. Format is: <number> B|KB|MB|GB|%/)
+          end
+        end
+        describe 'set bad limit on restart' do
+          before do
+            merged_manifest_properties['nats']['mem_limit']['restart'] = '100 potatoes'
+          end
+          it 'raises an error' do
+            expect do
+              template.render(merged_manifest_properties)
+            end.to raise_error(/Bad 'nats.mem_limit.restart' setting: 100 potatoes. Format is: <number> B|KB|MB|GB|%/)
+          end
+        end
+        describe 'set non-integer limit on restart' do
+          before do
+            merged_manifest_properties['nats']['mem_limit']['restart'] = 'mashed potatoes'
+          end
+          it 'raises an error' do
+            expect do
+              template.render(merged_manifest_properties)
+            end.to raise_error(/Bad 'nats.mem_limit.restart' setting: mashed potatoes. Format is: <number> B|KB|MB|GB|%/)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Depending on the deployment size of Cloud Foundry, 500 MB may not be enough memory for NATS.
We ran into issues where BOSH was restarting NATS VMs just because they reported this alert, even when there where no issues.

We would like to make the limits configurable, yet keep the current values as defaults so that this should be a no-op for everyone else.

- Remove the hard-coded memory limit
- Replace with with spec properties
- Keep current values as default