### PR TITLE
fix: Disable cluster connection pool to restore 2.9 defaults

### DIFF
--- a/jobs/nats-tls/templates/nats-tls.conf.erb
+++ b/jobs/nats-tls/templates/nats-tls.conf.erb
@@ -103,6 +103,7 @@ cluster {
   no_advertise: <%= p("nats.no_advertise") %>
   host: "<%= p("nats.cluster_host", spec.address) %>"
   port: <%= p("nats.cluster_port") %>
+  pool_size: -1
 
   <%- if nats_auth_required and nats_user and nats_password -%>
   authorization {

--- a/spec/nats-tls/nats_tls_config_spec.rb
+++ b/spec/nats-tls/nats_tls_config_spec.rb
@@ -121,6 +121,7 @@ cluster \{
   no_advertise: false
   host: "10.0.0.1"
   port: 4223
+  pool_size: -1
 
   authorization \{
     user: "my-user"
@@ -199,6 +200,7 @@ cluster \{
   no_advertise: false
   host: "10.0.0.1"
   port: 4223
+  pool_size: -1
 
   authorization \{
     user: "my-user"
@@ -280,6 +282,7 @@ cluster \{
   no_advertise: false
   host: "10.0.0.1"
   port: 4223
+  pool_size: -1
 
   authorization \{
     user: "my-user"


### PR DESCRIPTION
With the bump of nats 2.9 -> 2.10 a connection pool feature was introduced.
For details, see [this link](https://docs.nats.io/running-a-nats-service/configuration/clustering/v2_routes#connection-pooling)

However, the pool is only used if different [accounts](https://docs.nats.io/running-a-nats-service/configuration/securing_nats/accounts) are used for multi-tenancy. This is a feature we don't currently use in Cloud Foundry. 
When using NATS in a cluster, this will add unwanted complexity, because by default 3 connections will be opened to each peer in the cluster. Only one of those connections will be used for actual traffic, the other two will be idling around and confuse everyone.

Therefore, I vote for disabling the conn-pool feature. When the value is set to -1, the pool will be turned off again.

This PR sets the value to -1 and makes everyone's lives a lot easier.