### PR TITLE
Make nats conf yaml take 2

### DIFF
--- a/jobs/nats/templates/nats.conf.erb
+++ b/jobs/nats/templates/nats.conf.erb
@@ -56,43 +56,43 @@ debug: <%= p("nats.debug") %>
 trace: <%= p("nats.trace") %>
 logtime: true
 
-authorization {
-  user: "<%= p("nats.user") %>"
-  password: "<%= p("nats.password") %>"
-  timeout: <%= p("nats.authorization_timeout") %>
+authorization: {
+  user: "<%= p("nats.user") %>",
+  password: "<%= p("nats.password") %>",
+  timeout: <%= p("nats.authorization_timeout") %>,
 }
 
-cluster {
-  no_advertise: <%= p("nats.no_advertise") %>
-  host: "<%= p("nats.cluster_host", spec.address) %>"
-  port: <%= p("nats.cluster_port") %>
+cluster: {
+  no_advertise: <%= p("nats.no_advertise") %>,
+  host: "<%= p("nats.cluster_host", spec.address) %>",
+  port: <%= p("nats.cluster_port") %>,
 
-  authorization {
-    user: "<%= p("nats.user") %>"
-    password: "<%= p("nats.password") %>"
-    timeout: <%= p("nats.authorization_timeout") %>
-  }
+  authorization: {
+    user: "<%= p("nats.user") %>",
+    password: "<%= p("nats.password") %>",
+    timeout: <%= p("nats.authorization_timeout") %>,
+  },
 
   <% if p("nats.internal.tls.enabled") %>
-  tls {
-    ca_file: "/var/vcap/jobs/nats/config/internal_tls/ca.pem"
-    cert_file: "/var/vcap/jobs/nats/config/internal_tls/certificate.pem"
-    key_file: "/var/vcap/jobs/nats/config/internal_tls/private_key.pem"
+  tls: {
+    ca_file: "/var/vcap/jobs/nats/config/internal_tls/ca.pem",
+    cert_file: "/var/vcap/jobs/nats/config/internal_tls/certificate.pem",
+    key_file: "/var/vcap/jobs/nats/config/internal_tls/private_key.pem",
     cipher_suites: [
       "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
-      "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
-    ]
+      "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+    ],
     curve_preferences: [
-      "CurveP384"
-    ]
-    timeout: 5 # seconds
-    verify: true
-  }
+      "CurveP384",
+    ],
+    timeout: 5, # seconds
+    verify: true,
+  },
   <% end %>
 
-  routes = [
+  routes: [
     <% nats_peers.each do |peer| %>
-    <%= peer.url %>
+    <%= peer.url %>,
     <% end %>
   ]
 }

--- a/spec/nats-tls/nats_tls_config_spec.rb
+++ b/spec/nats-tls/nats_tls_config_spec.rb
@@ -75,67 +75,67 @@ module Bosh::Template::Test
           'address' => '10.0.0.1'
         }
       end
-       let(:expected_hash) do
-            {
-              'net' => '10.0.0.1',
-              'port' => 4222,
-              'prof_port' => 0,
-              'http' => '0.0.0.0:0',
-              'write_deadline' => '2s',
-              'debug' => false,
-              'trace' => false,
-              'logtime' => true,
-              'authorization' => {
-                'user' => "my-user",
-                'password' => "my-password",
-                'timeout' => 15,
-              },
-              'tls' => {
-                'ca_file' => "/var/vcap/jobs/nats-tls/config/external_tls/ca.pem",
-                'cert_file' => "/var/vcap/jobs/nats-tls/config/external_tls/certificate.pem",
-                'key_file' => "/var/vcap/jobs/nats-tls/config/external_tls/private_key.pem",
-                'cipher_suites' => [
-                  "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
-                  "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
-                ],
-                'curve_preferences' => [
-                  "CurveP384",
-                ],
-                'timeout' => 5,
-                'verify' => true,
-              },
-              'cluster' => {
-                'no_advertise' => false,
-                'host' => "10.0.0.1",
-                'port' => 4223,
-                'pool_size' => -1,
-                'authorization' => {
-                  'user' => "my-user",
-                  'password' => "my-password",
-                  'timeout' => 15,
-                },
-                'tls' => {
-                  'ca_file' => "/var/vcap/jobs/nats-tls/config/internal_tls/ca.pem",
-                  'cert_file' => "/var/vcap/jobs/nats-tls/config/internal_tls/certificate.pem",
-                  'key_file' => "/var/vcap/jobs/nats-tls/config/internal_tls/private_key.pem",
-                  'cipher_suites' => [
-                    "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
-                    "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
-                  ],
-                  'curve_preferences' => [
-                    "CurveP384",
-                  ],
-                  'timeout' => 5,
-                  'verify' => true,
-                },
-                'routes' => [
-                 'nats-route://my-user:my-password@meowmeowmeow.my-host:4223',
-                 'nats-route://my-user:my-password@a-b-c-d.my-host:4223',
-                ]
-              },
-              'no_sys_acc' => true,
-            }
-       end
+      let(:expected_hash) do
+           {
+             'net' => '10.0.0.1',
+             'port' => 4222,
+             'prof_port' => 0,
+             'http' => '0.0.0.0:0',
+             'write_deadline' => '2s',
+             'debug' => false,
+             'trace' => false,
+             'logtime' => true,
+             'authorization' => {
+               'user' => "my-user",
+               'password' => "my-password",
+               'timeout' => 15,
+             },
+             'tls' => {
+               'ca_file' => "/var/vcap/jobs/nats-tls/config/external_tls/ca.pem",
+               'cert_file' => "/var/vcap/jobs/nats-tls/config/external_tls/certificate.pem",
+               'key_file' => "/var/vcap/jobs/nats-tls/config/external_tls/private_key.pem",
+               'cipher_suites' => [
+                 "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+                 "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+               ],
+               'curve_preferences' => [
+                 "CurveP384",
+               ],
+               'timeout' => 5,
+               'verify' => true,
+             },
+             'cluster' => {
+               'no_advertise' => false,
+               'host' => "10.0.0.1",
+               'port' => 4223,
+               'pool_size' => -1,
+               'authorization' => {
+                 'user' => "my-user",
+                 'password' => "my-password",
+                 'timeout' => 15,
+               },
+               'tls' => {
+                 'ca_file' => "/var/vcap/jobs/nats-tls/config/internal_tls/ca.pem",
+                 'cert_file' => "/var/vcap/jobs/nats-tls/config/internal_tls/certificate.pem",
+                 'key_file' => "/var/vcap/jobs/nats-tls/config/internal_tls/private_key.pem",
+                 'cipher_suites' => [
+                   "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+                   "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+                 ],
+                 'curve_preferences' => [
+                   "CurveP384",
+                 ],
+                 'timeout' => 5,
+                 'verify' => true,
+               },
+               'routes' => [
+                'nats-route://my-user:my-password@meowmeowmeow.my-host:4223',
+                'nats-route://my-user:my-password@a-b-c-d.my-host:4223',
+               ]
+             },
+             'no_sys_acc' => true,
+           }
+      end
 
       describe 'nats-tls job' do
 

--- a/spec/nats/nats_config_spec.rb
+++ b/spec/nats/nats_config_spec.rb
@@ -57,10 +57,55 @@ module Bosh::Template::Test
         ]
       end
 
+      let(:expected_hash) do
+           {
+             'net' => '10.0.0.1',
+             'port' => 4222,
+             'prof_port' => 0,
+             'http' => '0.0.0.0:0',
+             'write_deadline' => '2s',
+             'debug' => false,
+             'trace' => false,
+             'logtime' => true,
+             'authorization' => {
+               'user' => "my-user",
+               'password' => "my-password",
+               'timeout' => 15,
+             },
+             'cluster' => {
+               'no_advertise' => true,
+               'host' => "10.0.0.1",
+               'port' => 4223,
+               'authorization' => {
+                 'user' => "my-user",
+                 'password' => "my-password",
+                 'timeout' => 15,
+               },
+               'tls' => {
+                 'ca_file' => "/var/vcap/jobs/nats/config/internal_tls/ca.pem",
+                 'cert_file' => "/var/vcap/jobs/nats/config/internal_tls/certificate.pem",
+                 'key_file' => "/var/vcap/jobs/nats/config/internal_tls/private_key.pem",
+                 'cipher_suites' => [
+                   "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+                   "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+                 ],
+                 'curve_preferences' => [
+                   "CurveP384",
+                 ],
+                 'timeout' => 5,
+                 'verify' => true,
+               },
+               'routes' => [
+                'nats-route://my-user:my-password@meowmeowmeow.my-host:4223',
+                'nats-route://my-user:my-password@a-b-c-d.my-host:4223',
+               ]
+             },
+             'no_sys_acc' => true,
+           }
+      end
+
       let(:spec) do
-        {
-          'address' => '10.0.0.1'
-        }
+        { 'address' => '10.0.0.1' }
       end
 
       describe 'nats job' do

--- a/spec/nats/nats_config_spec.rb
+++ b/spec/nats/nats_config_spec.rb
@@ -71,198 +71,42 @@ module Bosh::Template::Test
           let(:template) { job.template('config/nats.conf') }
 
           it 'renders the template with the provided manifest properties' do
-            rendered_template = template.render(merged_manifest_properties, consumes: links, spec: spec)
-expected_template =  %{
-net: "10.0.0.1"
-port: 4222
-prof_port: 0
-http: "0.0.0.0:0"
-write_deadline: "2s"
-
-debug: false
-trace: false
-logtime: true
-
-authorization \{
-  user: "my-user"
-  password: "my-password"
-  timeout: 15
-\}
-
-cluster \{
-  no_advertise: true
-  host: "10.0.0.1"
-  port: 4223
-
-  authorization \{
-    user: "my-user"
-    password: "my-password"
-    timeout: 15
-  \}
-
-  
-  tls \{
-    ca_file: "/var/vcap/jobs/nats/config/internal_tls/ca.pem"
-    cert_file: "/var/vcap/jobs/nats/config/internal_tls/certificate.pem"
-    key_file: "/var/vcap/jobs/nats/config/internal_tls/private_key.pem"
-    cipher_suites: \[
-      "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
-      "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
-    \]
-    curve_preferences: \[
-      "CurveP384"
-    \]
-    timeout: 5 # seconds
-    verify: true
-  \}
-  
-
-  routes = \[
-    
-    nats-route://my-user:my-password@meowmeowmeow.my-host:4223
-    
-    nats-route://my-user:my-password@a-b-c-d.my-host:4223
-    
-  \]
-\}
-}
-            expect(rendered_template).to include(expected_template)
+            rendered_hash = YAML.load(template.render(merged_manifest_properties, consumes: links, spec: spec))
+            expect(rendered_hash).to eq(expected_hash)
           end
+
           describe 'nats machine ips are provided' do
             before do
               merged_manifest_properties['nats']['machines'] = ['192.0.0.1', '198.5.4.3']
+              expected_hash['cluster']['routes'] =
+                [
+                  'nats-route://my-user:my-password@192.0.0.1:4223',
+                  'nats-route://my-user:my-password@198.5.4.3:4223'
+                ]
             end
 
             it 'renders the template with the provided manifest properties' do
-              rendered_template = template.render(merged_manifest_properties, consumes: links, spec: spec)
-expected_template =  %{
-net: "10.0.0.1"
-port: 4222
-prof_port: 0
-http: "0.0.0.0:0"
-write_deadline: "2s"
-
-debug: false
-trace: false
-logtime: true
-
-authorization \{
-  user: "my-user"
-  password: "my-password"
-  timeout: 15
-\}
-
-cluster \{
-  no_advertise: true
-  host: "10.0.0.1"
-  port: 4223
-
-  authorization \{
-    user: "my-user"
-    password: "my-password"
-    timeout: 15
-  \}
-
-  
-  tls \{
-    ca_file: "/var/vcap/jobs/nats/config/internal_tls/ca.pem"
-    cert_file: "/var/vcap/jobs/nats/config/internal_tls/certificate.pem"
-    key_file: "/var/vcap/jobs/nats/config/internal_tls/private_key.pem"
-    cipher_suites: \[
-      "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
-      "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
-    \]
-    curve_preferences: \[
-      "CurveP384"
-    \]
-    timeout: 5 # seconds
-    verify: true
-  \}
-  
-
-  routes = \[
-    
-    nats-route://my-user:my-password@192.0.0.1:4223
-    
-    nats-route://my-user:my-password@198.5.4.3:4223
-    
-  \]
-\}
-}
-
-              expect(rendered_template).to include(expected_template)
+              rendered_hash = YAML.load(template.render(merged_manifest_properties, consumes: links, spec: spec))
+              expect(rendered_hash).to eq(expected_hash)
             end
           end
+
           describe 'nats machine ips and tls_cluster_port are provided' do
             before do
               merged_manifest_properties['nats']['machines'] = ['192.0.0.1', '198.5.4.3']
               merged_manifest_properties['nats']['tls_cluster_port'] = '4225'
+              expected_hash['cluster']['routes'] =
+                [
+                  'nats-route://my-user:my-password@192.0.0.1:4223',
+                  'nats-route://my-user:my-password@198.5.4.3:4223',
+                  'nats-route://my-user:my-password@192.0.0.1:4225',
+                  'nats-route://my-user:my-password@198.5.4.3:4225',
+                ]
             end
 
             it 'renders the template with the provided manifest properties' do
-              rendered_template = template.render(merged_manifest_properties, consumes: links, spec: spec)
-expected_template =  %{
-net: "10.0.0.1"
-port: 4222
-prof_port: 0
-http: "0.0.0.0:0"
-write_deadline: "2s"
-
-debug: false
-trace: false
-logtime: true
-
-authorization \{
-  user: "my-user"
-  password: "my-password"
-  timeout: 15
-\}
-
-cluster \{
-  no_advertise: true
-  host: "10.0.0.1"
-  port: 4223
-
-  authorization \{
-    user: "my-user"
-    password: "my-password"
-    timeout: 15
-  \}
-
-  
-  tls \{
-    ca_file: "/var/vcap/jobs/nats/config/internal_tls/ca.pem"
-    cert_file: "/var/vcap/jobs/nats/config/internal_tls/certificate.pem"
-    key_file: "/var/vcap/jobs/nats/config/internal_tls/private_key.pem"
-    cipher_suites: \[
-      "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
-      "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
-    \]
-    curve_preferences: \[
-      "CurveP384"
-    \]
-    timeout: 5 # seconds
-    verify: true
-  \}
-  
-
-  routes = \[
-    
-    nats-route://my-user:my-password@192.0.0.1:4223
-    
-    nats-route://my-user:my-password@198.5.4.3:4223
-    
-    nats-route://my-user:my-password@192.0.0.1:4225
-    
-    nats-route://my-user:my-password@198.5.4.3:4225
-    
-  \]
-\}
-
-no_sys_acc: true
-}
-
-              expect(rendered_template).to include(expected_template)
+              rendered_hash = YAML.load(template.render(merged_manifest_properties, consumes: links, spec: spec))
+              expect(rendered_hash).to eq(expected_hash)
             end
           end
         end


### PR DESCRIPTION
Turns the nats config into valid yaml so we can parse it in tests.

Nats allows lots of different syntactic options for defining configs. We were choosing some that were yaml compatible and others that weren't. I have changed the config to be within the yaml spec.