### PR TITLE
fix: log stdout and stderr from nats-runner

### DIFF
--- a/src/code.cloudfoundry.org/nats-v2-migrate/nats-wrapper/main.go
+++ b/src/code.cloudfoundry.org/nats-v2-migrate/nats-wrapper/main.go
@@ -186,6 +186,10 @@ func NewNATSSession(binPath string, configPath string) (*NATSSession, error) {
 		lock:     &sync.Mutex{},
 		exitCode: -1,
 	}
+
+	session.command.Stdout = os.Stdout
+	session.command.Stderr = os.Stderr
+	
 	err := session.command.Start()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Related to issue: https://github.com/cloudfoundry/nats-release/issues/66
Forward logs from stderr and stdout of nats process to os.Stderr and os.Stdout

Log example: 

```
[14] 2023/12/11 13:14:45.951315 [ERR] 10.1.1.5:55238 - cid:69 - TLS handshake timeout
[14] 2023/12/11 13:14:41.353447 [INF] 10.1.1.5:4225 - rid:18 - Route connection created

```
