### PR TITLE
Remove replace directive for gnatsd

### DIFF
--- a/src/code.cloudfoundry.org/go.mod
+++ b/src/code.cloudfoundry.org/go.mod
@@ -4,8 +4,6 @@ go 1.22.0
 
 toolchain go1.22.3
 
-replace github.com/nats-io/gnatsd => github.com/nats-io/gnatsd v1.4.1
-
 require (
 	code.cloudfoundry.org/cf-networking-helpers v0.17.0
 	code.cloudfoundry.org/lager/v3 v3.6.0

--- a/src/code.cloudfoundry.org/vendor/modules.txt
+++ b/src/code.cloudfoundry.org/vendor/modules.txt
@@ -41,7 +41,7 @@ github.com/klauspost/compress/s2
 # github.com/minio/highwayhash v1.0.3
 ## explicit; go 1.15
 github.com/minio/highwayhash
-# github.com/nats-io/gnatsd v1.4.1 => github.com/nats-io/gnatsd v1.4.1
+# github.com/nats-io/gnatsd v1.4.1
 ## explicit
 github.com/nats-io/gnatsd
 github.com/nats-io/gnatsd/conf
@@ -243,4 +243,3 @@ google.golang.org/protobuf/runtime/protoimpl
 # gopkg.in/yaml.v3 v3.0.1
 ## explicit
 gopkg.in/yaml.v3
-# github.com/nats-io/gnatsd => github.com/nats-io/gnatsd v1.4.1


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
This PR removes the `replace` directive for `gnatsd` allowing it to be upgraded to the latest version.


Backward Compatibility
---------------
Breaking Change? **No**