### PR TITLE
Pin gnatsd for compatibility with NATS v1

### DIFF
--- a/src/code.cloudfoundry.org/go.mod
+++ b/src/code.cloudfoundry.org/go.mod
@@ -4,6 +4,9 @@ go 1.22.0
 
 toolchain go1.22.3
 
+// Pin gnatsd to maintain compatibility with NATS v1
+replace github.com/nats-io/gnatsd => github.com/nats-io/gnatsd v1.4.1
+
 require (
 	code.cloudfoundry.org/cf-networking-helpers v0.17.0
 	code.cloudfoundry.org/lager/v3 v3.6.0

--- a/src/code.cloudfoundry.org/vendor/modules.txt
+++ b/src/code.cloudfoundry.org/vendor/modules.txt
@@ -41,7 +41,7 @@ github.com/klauspost/compress/s2
 # github.com/minio/highwayhash v1.0.3
 ## explicit; go 1.15
 github.com/minio/highwayhash
-# github.com/nats-io/gnatsd v1.4.1
+# github.com/nats-io/gnatsd v1.4.1 => github.com/nats-io/gnatsd v1.4.1
 ## explicit
 github.com/nats-io/gnatsd
 github.com/nats-io/gnatsd/conf
@@ -243,3 +243,4 @@ google.golang.org/protobuf/runtime/protoimpl
 # gopkg.in/yaml.v3 v3.0.1
 ## explicit
 gopkg.in/yaml.v3
+# github.com/nats-io/gnatsd => github.com/nats-io/gnatsd v1.4.1


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Pin `gnatsd` to maintain compatibility with NATS v1


Backward Compatibility
---------------
Breaking Change? **No**
