### PR TITLE
Add a little more tolerance for the migration test since CI more CPU bound than it used to be

### DIFF
--- a/src/code.cloudfoundry.org/nats-v2-migrate/integration/migrate_test.go
+++ b/src/code.cloudfoundry.org/nats-v2-migrate/integration/migrate_test.go
@@ -292,7 +292,7 @@ var _ = Describe("Migrate", func() {
 							})
 
 							It("exits with success", func() {
-								Eventually(migrateSess).Should(gexec.Exit(0))
+								Eventually(migrateSess, 2*time.Second).Should(gexec.Exit(0))
 							})
 						})
 


### PR DESCRIPTION


- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------


Backward Compatibility
---------------
Breaking Change? no