### PR TITLE
set log file in nats config

### DIFF
--- a/jobs/nats-tls/templates/nats-tls.conf.erb
+++ b/jobs/nats-tls/templates/nats-tls.conf.erb
@@ -81,6 +81,7 @@ write_deadline: "<%= p("nats.write_deadline") %>"
 debug: <%= p("nats.debug") %>
 trace: <%= p("nats.trace") %>
 logtime: true
+log_file: "/var/vcap/sys/log/nats-tls/nats.log"
 
 <%- if nats_auth_required and nats_user and nats_password -%>
 authorization: {

--- a/jobs/nats/templates/nats.conf.erb
+++ b/jobs/nats/templates/nats.conf.erb
@@ -55,6 +55,7 @@ write_deadline: "<%= p("nats.write_deadline") %>"
 debug: <%= p("nats.debug") %>
 trace: <%= p("nats.trace") %>
 logtime: true
+log_file: "/var/vcap/sys/log/nats/nats.log"
 
 authorization: {
   user: "<%= p("nats.user") %>",

--- a/spec/nats-tls/nats_tls_config_spec.rb
+++ b/spec/nats-tls/nats_tls_config_spec.rb
@@ -85,6 +85,7 @@ module Bosh::Template::Test
              'debug' => false,
              'trace' => false,
              'logtime' => true,
+             'log_file' => '/var/vcap/sys/log/nats-tls/nats.log',
              'authorization' => {
                'user' => "my-user",
                'password' => "my-password",

--- a/spec/nats/nats_config_spec.rb
+++ b/spec/nats/nats_config_spec.rb
@@ -67,6 +67,7 @@ module Bosh::Template::Test
              'debug' => false,
              'trace' => false,
              'logtime' => true,
+             'log_file' => '/var/vcap/sys/log/nats/nats.log',
              'authorization' => {
                'user' => "my-user",
                'password' => "my-password",

--- a/src/code.cloudfoundry.org/nats-v2-migrate/nats-wrapper/main.go
+++ b/src/code.cloudfoundry.org/nats-v2-migrate/nats-wrapper/main.go
@@ -187,9 +187,6 @@ func NewNATSSession(binPath string, configPath string) (*NATSSession, error) {
 		exitCode: -1,
 	}
 
-	session.command.Stdout = os.Stdout
-	session.command.Stderr = os.Stderr
-
 	err := session.command.Start()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
- [X] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Nats has stopped logging. Again. There is an old issue about this here:  https://github.com/cloudfoundry/nats-release/issues/66. It was fixed, but for some reason the fix is no longer working. 

In this PR I explicitly set the log file in the nats config. If we ever got rid of the nats-wrapper and started nats by bpm directly we would not need to do this (I think). 

The new nats log is named: `nats.log`.


Backward Compatibility
---------------
This changes the name of the nats logs (when it used to log at all). I think this is okay and does not need to be considered a breaking change.
