### PR TITLE
expose CLIENT certs

### DIFF
--- a/jobs/nats/spec
+++ b/jobs/nats/spec
@@ -40,9 +40,9 @@ provides:
   - nats.write_deadline
   - nats.disable
   - nats.migrate_server.port
-  - nats.migrate_server.tls.ca:
-  - nats.migrate_server.tls.certificate:
-  - nats.migrate_server.tls.private_key:
+  - nats.migrate_client.tls.ca:
+  - nats.migrate_client.tls.certificate:
+  - nats.migrate_client.tls.private_key:
 
 consumes:
 - name: nats


### PR DESCRIPTION
- [X] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Expose client certs (not server certs, oops)


Backward Compatibility
---------------
No. This comes minutes after merging (but never releasing) exposing the server certs.
