### PR TITLE
Remove typo from link property names

### DIFF
--- a/jobs/nats/spec
+++ b/jobs/nats/spec
@@ -40,9 +40,9 @@ provides:
   - nats.write_deadline
   - nats.disable
   - nats.migrate_server.port
-  - nats.migrate_client.tls.ca:
-  - nats.migrate_client.tls.certificate:
-  - nats.migrate_client.tls.private_key:
+  - nats.migrate_client.tls.ca
+  - nats.migrate_client.tls.certificate
+  - nats.migrate_client.tls.private_key
 
 consumes:
 - name: nats


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Hopefully resolves this error on the cf-networking pipeline: 

```
Task 76 | 17:40:18 | Error: undefined method `split' for {"nats.migrate_client.tls.ca"=>nil}:Hash
```

Backward Compatibility
---------------
Breaking Change? no