### PR TITLE
cleanup nats spec

### DIFF
--- a/jobs/nats-tls/spec
+++ b/jobs/nats-tls/spec
@@ -5,7 +5,6 @@ description: "TLS-secured NATS server providing a publish-subscribe messaging sy
 
 templates:
   nats-tls.conf.erb: config/nats-tls.conf
-  post-start.erb: bin/post-start
   bpm.yml.erb: config/bpm.yml
 
   internal_tls/ca.pem.erb: config/internal_tls/ca.pem

--- a/jobs/nats-tls/templates/bpm.yml.erb
+++ b/jobs/nats-tls/templates/bpm.yml.erb
@@ -12,7 +12,7 @@
   YAML.dump({
     'processes' => [
       {
-        'name' => 'nats',
+        'name' => 'nats-tls-wrapper',
         'limits' => {
           'open_files' => 100000
         },

--- a/jobs/nats/spec
+++ b/jobs/nats/spec
@@ -5,7 +5,6 @@ description: "NATS server providing a publish-subscribe messaging system for Clo
 
 templates:
   nats.conf.erb: config/nats.conf
-  post-start.erb: bin/post-start
   bpm.yml.erb: config/bpm.yml
 
   internal_tls/ca.pem.erb: config/internal_tls/ca.pem

--- a/jobs/nats/templates/bpm.yml.erb
+++ b/jobs/nats/templates/bpm.yml.erb
@@ -1,6 +1,6 @@
 ---
 processes:
-- name: nats
+- name: nats-wrapper
   limits:
     open_files: 100000
   executable: /var/vcap/packages/nats-server/bin/nats-server

--- a/spec/nats-tls/nats_tls_config_spec.rb
+++ b/spec/nats-tls/nats_tls_config_spec.rb
@@ -248,7 +248,7 @@ module Bosh::Template::Test
             expected_template = {
               'processes' => [
                 {
-                  'name' => 'nats',
+                  'name' => 'nats-tls-wrapper',
                   'limits' => {
                     'open_files' => 100000
                   },
@@ -294,7 +294,7 @@ module Bosh::Template::Test
               expected_template = {
                 'processes' => [
                   {
-                    'name' => 'nats',
+                    'name' => 'nats-tls-wrapper',
                     'limits' => {
                       'open_files' => 100000
                     },


### PR DESCRIPTION
- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
nats v1 cleanup updates
related: https://github.com/cloudfoundry/nats-release/pull/93
ci: https://ci.funtime.lol/teams/wg-arp-networking/pipelines/nats-release/jobs/prepare-env/builds/240


Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
